### PR TITLE
Remove empty .spec.names.shortNames default from backup CRD.

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.4.0"
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 0.1.9
+version: 0.1.10
 maintainers:
   - name: paulczar
     email: username.taken@gmail.com

--- a/charts/pxc-db/crds/crd.yaml
+++ b/charts/pxc-db/crds/crd.yaml
@@ -148,7 +148,6 @@ spec:
     listKind: PerconaXtraDBBackupList
     plural: perconaxtradbbackups
     singular: perconaxtradbbackup
-    shortNames: []
   scope: Namespaced
   versions:
     - name: v1alpha1

--- a/charts/pxc-operator/Chart.yaml
+++ b/charts/pxc-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.4.0"
 description: A Helm chart for Deploying the Percona XtraDB Cluster Operator Kubernetes
 name: pxc-operator
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 0.1.8
+version: 0.1.9
 maintainers:
   - name: paulczar
     email: username.taken@gmail.com

--- a/charts/pxc-operator/crds/crd.yaml
+++ b/charts/pxc-operator/crds/crd.yaml
@@ -148,7 +148,6 @@ spec:
     listKind: PerconaXtraDBBackupList
     plural: perconaxtradbbackups
     singular: perconaxtradbbackup
-    shortNames: []
   scope: Namespaced
   versions:
     - name: v1alpha1


### PR DESCRIPTION
When keeping a YAML manifest in sync using GitOps tools like ArgoCD, these tools report the manifest being out of sync when the live manifest in the cluster differs from the desired manifest in the source Git/Helm repository.

The `PerconaXtraDBBackup` CRD has an explicit empty list for its `.spec.names.shortNames` property. This is actually the default value, and in that case it apparently gets removed from the live manifest by k8s when applied. This causes the manifest to never become synced in tools like ArgoCD.

The fix is to remove the default empty value from the manifest, which will result in the same configuration on the cluster, but this time in sync with the source manifest.

This is how the issue manifests itself in ArgoCD specifically:
<img width="1606" alt="Screen Shot 2020-07-01 at 23 45 04" src="https://user-images.githubusercontent.com/1623909/86294777-86baeb80-bbf5-11ea-9ab2-77c242906de9.png">
