### PR TITLE
Allow S3 credentials to be specified in plain text

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.7.0"
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 0.1.16
+version: 0.1.17
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-db/templates/_helpers.tpl
+++ b/charts/pxc-db/templates/_helpers.tpl
@@ -50,12 +50,13 @@ This filters the backup.storages hash for S3 credentials. If we detect them, the
 {{- define "pxc-database.storages" -}}
 {{- $storages := dict -}}
 {{- range $key, $value := .Values.backup.storages -}}
-{{- if and (hasKey $value "type") (eq $value.type "s3") (hasKey $value "credentialsAccessKey") (hasKey $value "credentialsSecretKey") -}}
-{{- if hasKey $value "credentialsSecret" -}}
+{{- if and (hasKey $value "type") (eq $value.type "s3") (hasKey $value "s3") (hasKey (index $value "s3") "credentialsAccessKey") (hasKey (index $value "s3") "credentialsSecretKey") }}
+{{- if hasKey (index $value "s3") "credentialsSecret" -}}
 {{- fail "credentialsSecret and credentialsAccessKey/credentialsSecretKey isn't supported!" -}}
 {{- end -}}
 {{- $secretName := printf "%s-s3-%s" (include "pxc-database.fullname" $) $key -}}
-{{- $_value := set (omit $value "credentialsAccessKey" "credentialsSecretKey") "credentialsSecret" $secretName -}}
+{{- $s3 := set (omit (index $value "s3") "credentialsAccessKey" "credentialsSecretKey") "credentialsSecret" $secretName -}}
+{{- $_value := set (omit $value "s3") "s3" $s3 -}}
 {{- $_ := set $storages $key $_value -}}
 {{- else -}}
 {{- $_ := set $storages $key $value -}}

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -242,7 +242,7 @@ spec:
       timeBetweenUploads: {{ $backup.pitr.timeBetweenUploads }}
     {{- end }}
     storages:
-{{ $backup.storages | toYaml | indent 6 }}
+{{ include "pxc-database.storages" . | indent 6 }}
 {{- if $backup.enabled }}
     schedule:
 {{ $backup.schedule | toYaml | indent 6 }}

--- a/charts/pxc-db/templates/s3-secret.yaml
+++ b/charts/pxc-db/templates/s3-secret.yaml
@@ -1,0 +1,14 @@
+{{- range $key, $value := .Values.backup.storages }}
+{{- if and (hasKey $value "type") (eq $value.type "s3") (hasKey $value "credentialsAccessKey") (hasKey $value "credentialsSecretKey") }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pxc-database.fullname" $ }}-s3-{{ $key }}
+  labels:
+{{ include "pxc-database.labels" $ | indent 4 }}
+type: Opaque
+data:
+  AWS_ACCESS_KEY_ID: {{ $value.credentialsAccessKey | b64enc }}
+  AWS_SECRET_ACCESS_KEY: {{ $value.credentialsSecretKey | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/pxc-db/templates/s3-secret.yaml
+++ b/charts/pxc-db/templates/s3-secret.yaml
@@ -1,5 +1,5 @@
 {{- range $key, $value := .Values.backup.storages }}
-{{- if and (hasKey $value "type") (eq $value.type "s3") (hasKey $value "credentialsAccessKey") (hasKey $value "credentialsSecretKey") }}
+{{- if and (hasKey $value "type") (eq $value.type "s3") (hasKey $value "s3") (hasKey (index $value "s3") "credentialsAccessKey") (hasKey (index $value "s3") "credentialsSecretKey") }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,7 +8,7 @@ metadata:
 {{ include "pxc-database.labels" $ | indent 4 }}
 type: Opaque
 data:
-  AWS_ACCESS_KEY_ID: {{ $value.credentialsAccessKey | b64enc }}
-  AWS_SECRET_ACCESS_KEY: {{ $value.credentialsSecretKey | b64enc }}
+  AWS_ACCESS_KEY_ID: {{ index $value "s3" "credentialsAccessKey" | b64enc }}
+  AWS_SECRET_ACCESS_KEY: {{ index $value "s3" "credentialsSecretKey" | b64enc }}
 {{- end }}
 {{- end }}

--- a/charts/pxc-db/templates/s3-secret.yaml
+++ b/charts/pxc-db/templates/s3-secret.yaml
@@ -1,5 +1,6 @@
 {{- range $key, $value := .Values.backup.storages }}
 {{- if and (hasKey $value "type") (eq $value.type "s3") (hasKey $value "s3") (hasKey (index $value "s3") "credentialsAccessKey") (hasKey (index $value "s3") "credentialsSecretKey") }}
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -248,7 +248,10 @@ backup:
     #   type: s3
     #   s3:
     #     bucket: S3-BACKUP-BUCKET-NAME-HERE
+    #     # Use credentialsSecret OR credentialsAccessKey/credentialsSecretKey
     #     credentialsSecret: my-cluster-name-backup-s3
+    #     #credentialsAccessKey: REPLACE-WITH-AWS-ACCESS-KEY
+    #     #credentialsSecretKey: REPLACE-WITH-AWS-SECRET-KEY
     #     region: us-west-2
     #     endpointUrl: https://sfo2.digitaloceanspaces.com
     # s3-us-west-binlogs:


### PR DESCRIPTION
This makes it possible to specify the S3 credentials from the Helm chart by automatically creating a k8s Secret for them.