### PR TITLE
Fixed dns-suffix in values.yaml

### DIFF
--- a/charts/psmdb-db/values.yaml
+++ b/charts/psmdb-db/values.yaml
@@ -6,7 +6,7 @@
 # platform: kubernetes
 
 # Cluster DNS Suffix
-# DNSsuffix: .svc.cluster.local
+# DNSsuffix: svc.cluster.local
 
 pause: false
 allowUnsafeConfigurations: false


### PR DESCRIPTION
When `DNSsuffix` is prepended with a dot `.` it renders a double dot `..` in the domain. The example in the `values.yaml` should have this dot `.` removed.
