### PR TITLE
K8SPXC-562 Fix broken haproxy imagePullSecrets

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.6.0"
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 0.1.13
+version: 0.1.14
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -109,7 +109,7 @@ spec:
     image: {{ $haproxy.image.repository }}:{{ $haproxy.image.tag }}
     {{- if $haproxy.imagePullSecrets }}
     imagePullSecrets:
-    {{- $haproxy.imagePullSecrets | toYaml | indent 6 }}
+{{ $haproxy.imagePullSecrets | toYaml | indent 6 }}
     {{- end }}
 {{- if hasKey $haproxy "priorityClassName" }}
     priorityClassName: {{ $haproxy.priorityClassName }}


### PR DESCRIPTION
```
pxc:
  imagePullSecrets:
    - name: "some_secret"
haproxy:
  imagePullSecrets:
    - name: "some_secret"
```

Will result in the following error, `block sequence entries are not allowed in this context`, because the whitespace control is broken.