### PR TITLE
CLOUD-603 - remove obsolete install_local_path_provisioner for kind cluster

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,8 +39,6 @@ jobs:
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.1.0
-        with:
-          install_local_path_provisioner: true
         # Only build a kind cluster if there are chart changes to test.
         if: steps.list-changed.outputs.changed == 'true'
 


### PR DESCRIPTION
There was some warning which I missed that this option is obsolete, `kind` version 0.7.0+ supports this by default.
`Dynamic PersistentVolume Support is greatly enhanced with rancher.io/localhost-path integration out of the box`