### PR TITLE
CLOUD-617 - Update psmdb-operator helm chart to apiVersion 2

### DIFF
--- a/charts/psmdb-operator/Chart.yaml
+++ b/charts/psmdb-operator/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.6.0"
 description: A Helm chart for Deploying the Percona Kubernetes Operator for Percona Server for MongoDB
 name: psmdb-operator


### PR DESCRIPTION
This PR fixes the `psmdb-operator` helm chart to correctly declare itself as Helm apiVersion v2.

This fixes CRDs not being deployed when using tools that run `helm template` rather than `helm install`, such as ArgoCD.

Per [helm's documentation on upgrading from Helm v2 to Helm v3](https://helm.sh/docs/topics/v2_v3_migration/), Use of the `crds/` directory is a feature added in `apiVersion: v2`, but this helm chart includes the `crds/` directory with `apiVersion: v1` against the helm specifications. The chart should instead either correctly declare itself as a v2 chart, or use the `crd-install` hook to register it's CRDs according to the v1 specification.

This issue _may_ affect the other helm charts in this repository but they are outside of the scope of the work I'm doing and didn't want to blindly change things that I'm not able to test myself.