### PR TITLE
Issue K8SPXC-620 in jira. Backup cronjobs created for disabled backups

### DIFF
--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -243,5 +243,7 @@ spec:
     {{- end }}
     storages:
 {{ $backup.storages | toYaml | indent 6 }}
+{{- if $backup.enabled }}
     schedule:
 {{ $backup.schedule | toYaml | indent 6 }}
+{{- end }}


### PR DESCRIPTION
I have found a solution to resolve the bug mentioned in the above jira ticket. I have added a condition in 'cluster.yaml' file, after running the chart the cron job are no longer are getting created as the backup is disabled. 