### PR TITLE
Allow configuring the Service objects created

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.7.0"
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 0.1.16
+version: 0.1.17
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -125,6 +125,19 @@ spec:
 {{- if hasKey $haproxy "priorityClassName" }}
     priorityClassName: {{ $haproxy.priorityClassName }}
 {{- end }}
+{{- if hasKey $haproxy "externalTrafficPolicy" }}
+    externalTrafficPolicy: {{ $haproxy.externalTrafficPolicy }}
+{{- end }}
+{{- if hasKey $haproxy "loadBalancerSourceRanges" }}
+    loadBalancerSourceRanges: {{ $haproxy.loadBalancerSourceRanges }}
+{{- end }}
+{{- if hasKey $haproxy "serviceType" }}
+    serviceType: {{ $haproxy.serviceType }}
+{{- end }}
+{{- if hasKey $haproxy "serviceAnnotations" }}
+    serviceAnnotations:
+{{ $haproxy.serviceAnnotations | toYaml | indent 6 }}
+{{- end }}
     annotations:
 {{ $haproxy.annotations | toYaml | indent 6 }}
     labels:
@@ -161,6 +174,19 @@ spec:
     {{- end }}
 {{- if hasKey $proxysql "priorityClassName" }}
     priorityClassName: {{ $proxysql.priorityClassName }}
+{{- end }}
+{{- if hasKey $proxysql "externalTrafficPolicy" }}
+    externalTrafficPolicy: {{ $proxysql.externalTrafficPolicy }}
+{{- end }}
+{{- if hasKey $proxysql "loadBalancerSourceRanges" }}
+    loadBalancerSourceRanges: {{ $proxysql.loadBalancerSourceRanges }}
+{{- end }}
+{{- if hasKey $proxysql "serviceType" }}
+    serviceType: {{ $proxysql.serviceType }}
+{{- end }}
+{{- if hasKey $proxysql "serviceAnnotations" }}
+    serviceAnnotations:
+{{ $proxysql.serviceAnnotations | toYaml | indent 6 }}
 {{- end }}
     annotations:
 {{ $proxysql.annotations | toYaml | indent 6 }}


### PR DESCRIPTION
Support additional configuration for haproxy and proxysql to allow
users to specify several operator-supported options to configure the
Service objects.

- externalTrafficPolicy
- loadBalancerSourceRanges
- serviceAnnotations
- serviceType

This should provide the correct knobs for configuring external load
balancers on AWS, for example.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>