### PR TITLE
K8SPXC-827 - Add support for cluster wide feature

### DIFF
--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -41,7 +41,11 @@ spec:
           - percona-xtradb-cluster-operator
           env:
             - name: WATCH_NAMESPACE
+              {{- if .Values.watchAllNamespaces }}
+              value: ""
+              {{- else }}
               value: {{ default .Release.Namespace .Values.watchNamespace }}
+              {{- end }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/pxc-operator/templates/role-binding.yaml
+++ b/charts/pxc-operator/templates/role-binding.yaml
@@ -8,7 +8,11 @@ kind: ServiceAccount
 metadata:
   name: percona-xtradb-cluster-operator
 ---
+{{- if or .Values.watchNamespace .Values.watchAllNamespaces }}
+kind: ClusterRoleBinding
+{{- else }}
 kind: RoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "pxc-operator.fullname" . }}
@@ -20,11 +24,11 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "pxc-operator.fullname" . }}
-  {{- if .Values.watchNamespace }}
+  {{- if or .Values.watchNamespace .Values.watchAllNamespaces }}
   namespace: {{ .Release.Namespace }}
   {{- end }}
 roleRef:
-  {{- if .Values.watchNamespace }}
+  {{- if or .Values.watchNamespace .Values.watchAllNamespaces }}
   kind: ClusterRole
   {{- else }}
   kind: Role

--- a/charts/pxc-operator/templates/role.yaml
+++ b/charts/pxc-operator/templates/role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.watchNamespace }}
+{{- if or .Values.watchNamespace .Values.watchAllNamespaces }}
 kind: ClusterRole
 {{- else }}
 kind: Role
@@ -18,6 +18,18 @@ rules:
   - perconaxtradbclusterbackups/status
   - perconaxtradbclusterrestores
   - perconaxtradbclusterrestores/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
   verbs:
   - get
   - list

--- a/charts/pxc-operator/values.yaml
+++ b/charts/pxc-operator/values.yaml
@@ -13,6 +13,9 @@ image:
 # defaults to `.Release.namespace` if left blank
 # watchNamespace:
 
+# set if operator should be deployed in cluster wide mode. defaults to false
+watchAllNamespaces: false
+
 # set if you want to use a different operator name
 # defaults to `percona-xtradb-cluster-operator`
 # operatorName:


### PR DESCRIPTION
This PR adds a new value `watchAllNamespaces` which deploys the operator in cluster wide mode.

So `ClusterRole` and `ClusterRoleBinding` being used. `WATCH_NAMESPACE` is set to empty string.

This is based on the cluster wide example: https://www.percona.com/doc/kubernetes-operator-for-pxc/cluster-wide.html