### PR TITLE
support securityContext configuration

### DIFF
--- a/charts/pxc-db/production-values.yaml
+++ b/charts/pxc-db/production-values.yaml
@@ -50,6 +50,7 @@ pxc:
       cpu: 600m
     # db resources are sacred, so don't limit it.
     limits: {}
+  securityContext: {}
   nodeSelector: {}
   #  disktype: ssd
   affinity:
@@ -122,6 +123,7 @@ haproxy:
     limits: {}
       # memory: 1G
       # cpu: 600m
+  securityContext: {}
   nodeSelector: {}
   #  disktype: ssd
   affinity:

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -77,6 +77,8 @@ spec:
 {{ tpl ($pxc.resources.requests| toYaml) $ | indent 8}}
       limits:
 {{ tpl ($pxc.resources.limits | toYaml) $ | indent 8 }}
+    securityContext:
+{{ $pxc.securityContext | toYaml | indent 6 }}
     nodeSelector:
 {{ $pxc.nodeSelector | toYaml | indent 6 }}
     affinity:
@@ -148,6 +150,8 @@ spec:
 {{ $haproxy.resources.requests | toYaml | indent 8 }}
       limits:
 {{ $haproxy.resources.limits | toYaml | indent 8 }}
+    securityContext:
+{{ $haproxy.securityContext | toYaml | indent 6 }}
     nodeSelector:
 {{ $haproxy.nodeSelector | toYaml | indent 6 }}
     affinity:

--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -49,6 +49,7 @@ pxc:
     limits: {}
       # memory: 1G
       # cpu: 600m
+  securityContext: {}
   nodeSelector: {}
   #  disktype: ssd
   affinity:
@@ -128,6 +129,7 @@ haproxy:
     limits: {}
       # memory: 1G
       # cpu: 600m
+  securityContext: {}
   nodeSelector: {}
   #  disktype: ssd
   affinity:

--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -56,6 +56,11 @@ spec:
               scheme: HTTP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
+
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/pxc-operator/values.yaml
+++ b/charts/pxc-operator/values.yaml
@@ -37,6 +37,8 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+securityContext: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
adds support for container securityContexts, e.g.:

```yaml
        securityContext:
          runAsUser: 1000
          runAsGroup: 2000
          runAsNonRoot: true
```

This already works for the pxc-operator deployment and creates `PerconaXtraDBCluster` objects with correct securityContext.
But the configuration isn't interpreted and applied to pxc and haproxy statefulsets by the operator yet. securityContext is always empty. :/