### PR TITLE
Add support for pxc.sidecars

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.8.0"
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 0.1.17
+version: 0.1.18
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-db/README.md
+++ b/charts/pxc-db/README.md
@@ -54,6 +54,7 @@ The chart can be customized using the following configurable parameters:
 | `pxc.configuration`             | User defined MySQL options according to MySQL configuration file syntax       | ``     |
 | `pxc.resources.requests`                     | PXC Pods resource requests                                    | `{"memory": "1G", "cpu": "600m"}`                                      |
 | `pxc.resources.limits`                     | PXC Pods resource limits                                    | `{}`                                      |
+| `pxc.sidecars`                     | PXC Pods sidecars                                                 | `{}`                                            |
 | `pxc.nodeSelector`                  | PXC Pods key-value pairs setting for K8S node assingment                 | `{}`                                      |
 | `pxc.affinity.antiAffinityTopologyKey` | PXC Pods simple scheduling restriction on/off for host, zone, region         | `"kubernetes.io/hostname"` |
 | `pxc.affinity.advanced` | PXC Pods advanced scheduling restriction with match expression engine          | `{}` |

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -77,6 +77,8 @@ spec:
 {{ tpl ($pxc.resources.requests| toYaml) $ | indent 8}}
       limits:
 {{ tpl ($pxc.resources.limits | toYaml) $ | indent 8 }}
+    sidecars:
+{{ $pxc.sidecars | toYaml | indent 6 }}
     nodeSelector:
 {{ $pxc.nodeSelector | toYaml | indent 6 }}
     affinity:

--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -49,6 +49,7 @@ pxc:
     limits: {}
       # memory: 1G
       # cpu: 600m
+  sidecars: {}
   nodeSelector: {}
   #  disktype: ssd
   affinity:


### PR DESCRIPTION
Support for PXC pod sidecars have been added in 1.8.0 release of the
operator. This makes it configurable.