### PR TITLE
Add support for tolerations

### DIFF
--- a/charts/psmdb-db/templates/cluster.yaml
+++ b/charts/psmdb-db/templates/cluster.yaml
@@ -73,6 +73,10 @@ spec:
     nodeSelector:
 {{ $replset.nodeSelector | toYaml | indent 6 }}
     {{- end }}
+    {{- if $replset.tolerations }}
+    tolerations:
+{{ $replset.tolerations | toYaml | indent 6 }}
+    {{- end }}
     {{- if $replset.livenessProbe }}
     livenessProbe:
 {{ $replset.livenessProbe | toYaml | indent 6 }}
@@ -112,6 +116,10 @@ spec:
       {{- if $replset.arbiter.nodeSelector }}
       nodeSelector:
 {{ $replset.arbiter.nodeSelector | toYaml | indent 8 }}
+      {{- end }}
+      {{- if $replset.arbiter.tolerations }}
+      tolerations:
+{{ $replset.arbiter.tolerations | toYaml | indent 6 }}
       {{- end }}
     {{- if $replset.schedulerName }}
     schedulerName: {{ $replset.schedulerName }}
@@ -156,6 +164,10 @@ spec:
       {{- if .Values.sharding.configrs.nodeSelector }}
       nodeSelector:
 {{ .Values.sharding.configrs.nodeSelector | toYaml | indent 8 }}
+      {{- end }}
+      {{- if .Values.sharding.configrs.tolerations }}
+      tolerations:
+{{ .Values.sharding.configrs.tolerations | toYaml | indent 6 }}
       {{- end }}
       {{- if .Values.sharding.configrs.runtimeClass }}
       runtimeClassName: {{ .Values.sharding.configrs.runtimeClass }}
@@ -211,6 +223,10 @@ spec:
       {{- if .Values.sharding.mongos.nodeSelector }}
       nodeSelector:
 {{ .Values.sharding.mongos.nodeSelector | toYaml | indent 8 }}
+      {{- end }}
+      {{- if .Values.sharding.mongos.tolerations }}
+      tolerations:
+{{ .Values.sharding.mongos.tolerations | toYaml | indent 8 }}
       {{- end }}
       {{- if .Values.sharding.mongos.runtimeClass }}
       runtimeClassName: {{ .Values.sharding.mongos.runtimeClass }}


### PR DESCRIPTION
This PR simply adds tolerations for each pod templates in the cluster cr template.

This has been tested, except for the arbiter pods.