### PR TITLE
CLOUD-767 - inclusion of .Release.Namespace in metadata objects

### DIFF
--- a/charts/pxc-operator/Chart.yaml
+++ b/charts/pxc-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.0
 description: A Helm chart for Deploying the Percona XtraDB Cluster Operator Kubernetes
 name: pxc-operator
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.9.1
+version: 1.9.2
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "pxc-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pxc-operator.labels" . | indent 4 }}
 spec:
@@ -78,6 +79,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pxc-operator.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     name: {{ include "pxc-operator.name" . }}
 spec:

--- a/charts/pxc-operator/templates/role-binding.yaml
+++ b/charts/pxc-operator/templates/role-binding.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "pxc-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: percona-xtradb-cluster-operator
+  namespace: {{ .Release.Namespace }}
 ---
 {{- if or .Values.watchNamespace .Values.watchAllNamespaces }}
 kind: ClusterRoleBinding
@@ -16,6 +18,9 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "pxc-operator.fullname" . }}
+  {{- if and ( not .Values.watchNamespace ) ( not .Values.watchAllNamespaces ) }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   {{- if .Values.watchNamespace }}
   namespace: {{ .Values.watchNamespace }}
   {{- end }}

--- a/charts/pxc-operator/templates/role.yaml
+++ b/charts/pxc-operator/templates/role.yaml
@@ -6,6 +6,9 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "pxc-operator.fullname" . }}
+{{- if and ( not .Values.watchNamespace ) ( not .Values.watchAllNamespaces ) }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
 {{ include "pxc-operator.labels" . | indent 4 }}
 rules:


### PR DESCRIPTION
Description

In our specific case, we are using helm template to render templates that fully describe our cluster's state in a declarative way, and then we load them to kubernetes using kubectl apply, in a GitOps fashion.
In order for this to work, we need to include information about namespace inside the templates.
One way to do this, is by including

```
metadata:
    namespace: {{ .Release.Namespace }}
```

In all namespace-scoped resource definitions. 

My question is: would you accept PR with this functionality added? After some tests our additions did not brake helm's existing behaviour.

