### PR TITLE
Fix disabling backup for Percona XtraDB Cluster Databases

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.0
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.9.1
+version: 1.9.2
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -311,11 +311,8 @@ spec:
 {{ tpl ($pmm.resources.limits | toYaml) $ | indent 8 }}
   {{- end }}
   {{- $backup := .Values.backup }}
-
+  {{- if $backup.enabled }}
   backup:
-  {{- if not $backup.enabled }}
-    enabled: false
-  {{- end }}
     image: {{ include "pxc-db.backup-image" . }}
     {{- if $backup.imagePullSecrets }}
     imagePullSecrets:
@@ -331,7 +328,6 @@ spec:
     {{- end }}
     storages:
 {{ include "pxc-database.storages" . | indent 6 }}
-{{- if $backup.enabled }}
     schedule:
 {{ $backup.schedule | toYaml | indent 6 }}
 {{- end }}


### PR DESCRIPTION
There is no `enabled` field in `.PerconaXtraDBCluster.spec.backup`.
For this reason, when I'm turn off the backup:
```diff
diff --git a/charts/pxc-db/values.yaml b/charts/pxc-db/values.yaml
index 567736b..b80e0c4 100644
--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -374,7 +374,7 @@ pmm:
     limits: {}

 backup:
-  enabled: true
+  enabled: false
   image: ""
   imagePullSecrets: []
   # - name: private-registry-credentials
```
I see the error:
```bash
Error: UPGRADE FAILED: release xtradb failed, and has been rolled back due to atomic being set: cannot patch "xtradb-pxc-db" with kind PerconaXtraDBCluster: admission webhook "validationwebhook.pxc.percona.com" denied the request: json: unknown field "enabled"
deploying "xtradb": install: exit status 1
```
Signed-off-by: Renat Galiev <renat@galiev.net>