### PR TITLE
enable support podSecurityContext configuration for Percona XtraDB Cluster Databases

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.9.0
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.9.1
+version: 1.9.2
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -128,7 +128,10 @@ spec:
 {{ tpl ($pxc.readinessProbes | toYaml) $ | indent 6 }}
     livenessProbes:
 {{ tpl ($pxc.livenessProbes | toYaml) $ | indent 6 }}
-
+    {{- if $pxc.podSecurityContext }}
+    podSecurityContext:
+{{ tpl ($pxc.podSecurityContext | toYaml) $ | indent 6 }}
+    {{- end }}
   {{- if or (not .Values.haproxy.enabled) .Values.proxysql.enabled }}
   haproxy:
     enabled: false
@@ -194,6 +197,10 @@ spec:
 {{ tpl ($haproxy.readinessProbes | toYaml) $ | indent 6 }}
     livenessProbes:
 {{ tpl ($haproxy.livenessProbes | toYaml) $ | indent 6 }}
+    {{- if $haproxy.podSecurityContext }}
+    podSecurityContext:
+{{ tpl ($haproxy.podSecurityContext | toYaml) $ | indent 6 }}
+    {{- end }}
   {{- end }}
   {{- if not .Values.proxysql.enabled }}
   proxysql:
@@ -277,6 +284,10 @@ spec:
     {{- end }}
     {{- end }}
     gracePeriod: {{ $proxysql.gracePeriod }}
+    {{- if $proxysql.podSecurityContext }}
+    podSecurityContext:
+{{ tpl ($proxysql.podSecurityContext | toYaml) $ | indent 6 }}
+    {{- end }}
   {{- end }}
   logcollector:
   {{- if not .Values.logcollector.enabled }}

--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -134,6 +134,11 @@ pxc:
     periodSeconds: 10
     successThreshold: 1
     failureThreshold: 3
+  # A custom Kubernetes Security Context for a Pod to be used instead of the default one
+  #podSecurityContext:
+  #  fsGroup: 1001
+  #  supplementalGroups:
+  #  - 1001
 
 haproxy:
   enabled: true
@@ -228,6 +233,11 @@ haproxy:
     periodSeconds: 30
     successThreshold: 1
     failureThreshold: 4
+  # A custom Kubernetes Security Context for a Pod to be used instead of the default one
+  #podSecurityContext:
+  #  fsGroup: 1001
+  #  supplementalGroups:
+  #  - 1001
 
 proxysql:
   enabled: false
@@ -346,6 +356,11 @@ proxysql:
     # storageClass: "-"
     accessMode: ReadWriteOnce
     size: 8Gi
+  # A custom Kubernetes Security Context for a Pod to be used instead of the default one
+  #podSecurityContext:
+  #  fsGroup: 1001
+  #  supplementalGroups:
+  #  - 1001
 
 logcollector:
   enabled: true


### PR DESCRIPTION
Percona XtraDB Cluster Databases support [pxc.podSecurityContext](https://www.percona.com/doc/kubernetes-operator-for-pxc/operator.html#pxc-podsecuritycontext) option, it becomes possible to configure this parameter.
Also CustomResource PerconaXtraDBCluster supports options: proxysql.podSecurityContext and haproxy.podSecurityContext.

Signed-off-by: Renat Galiev <renat@galiev.net>