### PR TITLE
fix: quote namespace in pxc-operator deploy

### DIFF
--- a/charts/pxc-operator/Chart.yaml
+++ b/charts/pxc-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.10.0
 description: A Helm chart for Deploying the Percona XtraDB Cluster Operator Kubernetes
 name: pxc-operator
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.10.0
+version: 1.10.1
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-operator/README.md
+++ b/charts/pxc-operator/README.md
@@ -20,7 +20,7 @@ To install the chart with the `pxc` release name using a dedicated namespace (re
 
 ```sh
 helm repo add percona https://percona.github.io/percona-helm-charts/
-helm install my-operator percona/pxc-operator --version 1.10.0 --namespace my-namespace
+helm install my-operator percona/pxc-operator --version 1.10.1 --namespace my-namespace
 ```
 
 The chart can be customized using the following configurable parameters:

--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
               {{- if .Values.watchAllNamespaces }}
               value: ""
               {{- else }}
-              value: {{ default .Release.Namespace .Values.watchNamespace }}
+              value: "{{ default .Release.Namespace .Values.watchNamespace }}"
               {{- end }}
             - name: POD_NAME
               valueFrom:


### PR DESCRIPTION
When trying to install `pxc-operator` in number-only namespace, e.g.
```
helm -n 7129496 install my-operator percona/pxc-operator
```
Helm fails with cryptic error:
```
Error: INSTALLATION FAILED: Deployment in version "v1" cannot be handled as a Deployment: v1.Deployment.Spec: v1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found 7, error found in #10 byte of ...|,"value":7129496},{"|..., bigger context ...|rator"],"env":[{"name":"WATCH_NAMESPACE","value":7129496},{"name":"POD_NAME","valueFrom":{"fieldRef"|...
```
Quoting namespace will fix errors like that.