### PR TITLE
Allow mongodb operator to be deployed cluster wide

### DIFF
--- a/charts/psmdb-operator/README.md
+++ b/charts/psmdb-operator/README.md
@@ -44,6 +44,9 @@ Alternatively a YAML file that specifies the values for the parameters can be pr
 helm install psmdb-operator -f values.yaml percona/psmdb-operator
 ```
 
+Please note that by default (if no `watchNamespace` specified) operator namespace is used as `watchNamespace`.
+Also operator will be watching cluster wide in case `all` is specified for `watchNamespace`.
+
 ## Deploy the database
 
 To deploy Percona Server for MongoDB run the following command:

--- a/charts/psmdb-operator/templates/_helpers.tpl
+++ b/charts/psmdb-operator/templates/_helpers.tpl
@@ -43,3 +43,12 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Watch namespace
+*/}}
+{{- define "psmdb-operator.watch" -}}
+{{- if ne .Values.watchNamespace "all" }}
+{{- default .Release.Namespace .Values.watchNamespace }}
+{{- end }}
+{{- end -}}

--- a/charts/psmdb-operator/templates/deployment.yaml
+++ b/charts/psmdb-operator/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
           - percona-server-mongodb-operator
           env:
             - name: WATCH_NAMESPACE
-              value: {{ default .Release.Namespace .Values.watchNamespace }}
+              value: {{ include "psmdb-operator.watch" . }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/charts/psmdb-operator/templates/namespace.yaml
+++ b/charts/psmdb-operator/templates/namespace.yaml
@@ -1,6 +1,0 @@
-{{ if .Values.watchNamespace }}
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Values.watchNamespace }}
-{{ end }}

--- a/charts/psmdb-operator/templates/role-binding.yaml
+++ b/charts/psmdb-operator/templates/role-binding.yaml
@@ -1,28 +1,50 @@
+{{- $watch := include "psmdb-operator.watch" . -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "psmdb-operator.fullname" . }}
 ---
+{{- if $watch }}
 kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-account-{{ include "psmdb-operator.fullname" . }}
-  {{- if .Values.watchNamespace }}
-  namespace: {{ .Values.watchNamespace }}
+  {{- if $watch }}
+  namespace: {{ $watch }}
   {{- end }}
   labels:
 {{ include "psmdb-operator.labels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "psmdb-operator.fullname" . }}
-  {{- if .Values.watchNamespace }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
 roleRef:
-  {{- if .Values.watchNamespace }}
-  kind: ClusterRole
-  {{- else }}
+  {{- if $watch }}
   kind: Role
+  {{- else }}
+  kind: ClusterRole
   {{- end }}
   name: {{ include "psmdb-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- if $watch }}
+{{- if ne $watch .Release.Namespace }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: service-account-{{ include "psmdb-operator.fullname" . }}
+  labels:
+{{ include "psmdb-operator.labels" . | indent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "psmdb-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "psmdb-operator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/charts/psmdb-operator/templates/role.yaml
+++ b/charts/psmdb-operator/templates/role.yaml
@@ -1,11 +1,15 @@
-{{- if .Values.watchNamespace }}
-kind: ClusterRole
-{{- else }}
+{{- $watch := include "psmdb-operator.watch" . -}}
+{{- if $watch }}
 kind: Role
+{{- else }}
+kind: ClusterRole
 {{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "psmdb-operator.fullname" . }}
+  {{- with $watch }}
+  namespace: {{ . }}
+  {{- end }}
   labels:
 {{ include "psmdb-operator.labels" . | indent 4 }}
 rules:
@@ -96,3 +100,28 @@ rules:
     - patch
     - delete
     - deletecollection
+{{- if $watch }}
+{{- if ne $watch .Release.Namespace }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "psmdb-operator.fullname" . }}
+  labels:
+{{ include "psmdb-operator.labels" . | indent 4 }}
+rules:
+  - apiGroups:
+    - ""
+    resources:
+    - pods
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+    - create
+    - update
+    - patch
+    - delete
+{{- end }}
+{{- end }}


### PR DESCRIPTION
This PR allows operator to be deployed cluster wide by using `all` as `watchNamespace` value. Also it will create separate `Role` and `RoleBinding` insteadof `ClusterRole` and `ClusterRoleBinding` when deploying with `watchNamespace` when it differs from operator namespace.

Please note that using `watchNamespace` previously wasn't working and will not work even now without patch to operator, cause of a bug: https://github.com/percona/percona-server-mongodb-operator/pull/889
