### PR TITLE
Additional image pull attributes

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.10.0
+appVersion: 1.10.1
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.10.0
+version: 1.10.1
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-db/README.md
+++ b/charts/pxc-db/README.md
@@ -178,6 +178,8 @@ The chart can be customized using the following configurable parameters:
 | |
 | `logcollector.enabled`            | Enable log collector container                                           | `true` |
 | `logcollector.image`              | Log collector image repository                                           | `percona/percona-xtradb-cluster-operator:1.10.0-logcollector` |
+| `logcollector.imagePullSecrets`   | Log collector pull secret                                                | `[]` |
+| `logcollector.imagePullPolicy`    | The policy used to update images                                         |  ``  |
 | `logcollector.configuration`      | User defined configuration for logcollector                              |  ``  |
 | `logcollector.resources.requests` | Log collector resource requests                                          | `{"memory": "100M", "cpu": "200m"}` |
 | `logcollector.resources.limits`   | Log collector resource limits                                            | `{}` |
@@ -185,6 +187,8 @@ The chart can be customized using the following configurable parameters:
 | `pmm.enabled` | Enable integration with [Percona Monitoring and Management software](https://www.percona.com/doc/kubernetes-operator-for-pxc/monitoring.html) | `false` |
 | `pmm.image.repository`              | PMM Container image repository                                           | `percona/pmm-client` |
 | `pmm.image.tag`                     | PMM Container image tag                                                  | `2.23.0`             |
+| `pmm.imagePullSecrets`              | PMM Container pull secret                                                | `[]` |
+| `pmm.imagePullPolicy`               | The policy used to update images                                         |  ``  |
 | `pmm.serverHost`                    | PMM server related K8S service hostname                                  | `monitoring-service` |
 | `pmm.serverUser`                    | Username for accessing PXC database internals                            | `admin` |
 | `pmm.resources.requests`            | PMM Container resource requests                                          | `{"memory": "150M", "cpu": "300m"}` |
@@ -193,6 +197,7 @@ The chart can be customized using the following configurable parameters:
 | `backup.enabled` | Enables backups for PXC cluster | `true` |
 | `backup.image`              | Backup Container image                                           | `percona/percona-xtradb-cluster-operator:1.10.0-pxc8.0-backup` |
 | `backup.imagePullSecrets`             | Backup Container pull secret                                                | `[]`                                      |
+| `backup.imagePullPolicy`              | The policy used to update images                                         |  ``  |
 | `backup.pitr.enabled`             | Enable point in time recovery                                                | `false`                                      |
 | `backup.pitr.storageName`             | Storage name for PITR                                                | `s3-us-west-binlogs`                                      |
 | `backup.pitr.timeBetweenUploads`             | Time between uploads for PITR                                                | `60`                                      |

--- a/charts/pxc-db/production-values.yaml
+++ b/charts/pxc-db/production-values.yaml
@@ -412,6 +412,8 @@ proxysql:
 logcollector:
   enabled: true
   image: ""
+  # imagePullPolicy: Always
+  imagePullSecrets: []
   # configuration: |
   #   [OUTPUT]
   #         Name  es
@@ -431,6 +433,8 @@ pmm:
   image:
     repository: percona/pmm-client
     tag: 2.23.0
+  # imagePullPolicy: Always
+  imagePullSecrets: []
   serverHost: monitoring-service
   serverUser: admin
   resources:
@@ -443,6 +447,7 @@ backup:
   enabled: true
   image: ""
   # serviceAccountName: percona-xtradb-cluster-operator
+  # imagePullPolicy: Always
   imagePullSecrets: []
   # - name: private-registry-credentials
   pitr:

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -375,6 +375,13 @@ spec:
     {{- $logcollector := .Values.logcollector }}
     enabled: true
     image: {{ include "pxc-db.logcollector-image" . }}
+    {{- if $logcollector.imagePullPolicy }}
+    imagePullPolicy: {{ $logcollector.imagePullPolicy }}
+    {{- end }}
+    {{- if $logcollector.imagePullSecrets }}
+    imagePullSecrets:
+    {{- $logcollector.imagePullSecrets | toYaml | indent 6 }}
+    {{- end }}
     {{- if $logcollector.configuration }}
     configuration: |
     {{ tpl $logcollector.configuration $ | nindent 6 }}

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -399,6 +399,13 @@ spec:
     {{- $pmm := .Values.pmm }}
     enabled: true
     image: {{ $pmm.image.repository }}:{{ $pmm.image.tag }}
+    {{- if $pmm.imagePullPolicy }}
+    imagePullPolicy: {{ $pmm.imagePullPolicy }}
+    {{- end }}
+    {{- if $pmm.imagePullSecrets }}
+    imagePullSecrets:
+    {{- $pmm.imagePullSecrets | toYaml | indent 6 }}
+    {{- end }}
     serverHost: {{ $pmm.serverHost }}
     serverUser: {{ $pmm.serverUser }}
     resources:
@@ -413,6 +420,9 @@ spec:
     image: {{ include "pxc-db.backup-image" . }}
     {{- if $backup.serviceAccountName }}
     serviceAccountName: {{ $backup.serviceAccountName }}
+    {{- end }}
+    {{- if $backup.imagePullPolicy }}
+    imagePullPolicy: {{ $backup.imagePullPolicy }}
     {{- end }}
     {{- if $backup.imagePullSecrets }}
     imagePullSecrets:

--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -428,6 +428,8 @@ proxysql:
 logcollector:
   enabled: true
   image: ""
+  # imagePullPolicy: Always
+  imagePullSecrets: []
   # configuration: |
   #   [OUTPUT]
   #         Name  es
@@ -447,6 +449,8 @@ pmm:
   image:
     repository: percona/pmm-client
     tag: 2.23.0
+  # imagePullPolicy: Always
+  imagePullSecrets: []
   serverHost: monitoring-service
   serverUser: admin
   resources:
@@ -459,6 +463,7 @@ backup:
   enabled: true
   image: ""
   # serviceAccountName: percona-xtradb-cluster-operator
+  # imagePullPolicy: Always
   imagePullSecrets: []
   # - name: private-registry-credentials
   pitr:


### PR DESCRIPTION
In an airgap environment, we need to set the imagePullPolicy to Never for images.  This PR allows us to set it for the missed images, as well as the imagePullSecrets.