### PR TITLE
fix: render pmm-secret from spec

### DIFF
--- a/charts/pg-db/Chart.yaml
+++ b/charts/pg-db/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg-db
 description: 'A Helm chart for Deploying the Percona PostgreSQL database by Percona Distribution for PostgreSQL Operator'
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: 1.2.0
 home: https://github.com/percona/percona-postgresql-operator
 maintainers:

--- a/charts/pg-db/templates/cluster.yaml
+++ b/charts/pg-db/templates/cluster.yaml
@@ -78,7 +78,7 @@ spec:
     enabled: {{ .Values.pmm.enabled }}
     image: {{ .Values.pmm.image.repository }}:{{ .Values.pmm.image.tag }}
     serverHost: {{ .Values.pmm.serverHost }}
-    serverUser: admin
+    serverUser: {{ .Values.pmm.username | default "admin" }} 
     pmmSecret: {{ include "pg-database.fullname" . }}-pmm-secret
     resources:
       requests:

--- a/charts/pg-db/templates/pmm-secret.yaml
+++ b/charts/pg-db/templates/pmm-secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.pmm.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pg-database.fullname" . }}-pmm-secret
+  annotations:
+    "helm.sh/hook": pre-install
+  labels:
+{{ include "pg-database.labels" . | indent 4 }}
+data:
+  password: {{ .Values.pmm.password | b64enc }}
+type: Opaque
+{{- end -}}

--- a/charts/pg-db/values.yaml
+++ b/charts/pg-db/values.yaml
@@ -49,6 +49,8 @@ pmm:
     repository: percona/pmm-client
     tag: 2.26.1
   serverHost: monitoring-service
+  username: admin
+  password: admin
   resources:
     requests:
       memory: 200M


### PR DESCRIPTION
So the PMM creds. best practice? I am sure admin is not right but how to you pass from a PMM chart to the db instances from the CRD spec? nothing seems to have that secret rendering now.

not sure if this is a db specific spec. perhaps could be defaulted in the operator? 

@denisok is there a design to default the PMM password? 

is a namespace spec needed other than the chart context? 