### PR TITLE
fix: percona operator image identification

### DIFF
--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
       terminationGracePeriodSeconds: 600
       containers:
-        - name: {{ .Chart.Name }}
+        - name: percona-xtradb-cluster-operator
           image: {{ include "pxc-operator.image" . }}
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           ports:


### PR DESCRIPTION
# Issue with percona cluster pxdb

The following line requires operator pods container name to equal "percona-xtradb-cluster-operator".

https://github.com/percona/percona-xtradb-cluster-operator/blob/9f096f007e2d53b74a4752c354c456a31c7fdd4f/pkg/controller/pxc/controller.go#L1401

Otherwise, you'll have this issue : 

```
operator image not found","errorVerbose":"operator image not found
github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc.operatorImageName
	/go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:1405
github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc.(*ReconcilePerconaXtraDBCluster).deploy
	/go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:545
github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc.(*ReconcilePerconaXtraDBCluster).Reconcile
	/go/src/github.com/percona/percona-xtradb-cluster-operator/pkg/controller/pxc/controller.go:307
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile
	/go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2
	/go/src/github.com/percona/percona-xtradb-cluster-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1571
```