### PR TITLE
K8SPXC-1048 - fixing sidecarVolumes in pxc-db chart

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.11.0
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.11.1
+version: 1.11.2
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-db/README.md
+++ b/charts/pxc-db/README.md
@@ -69,6 +69,7 @@ The chart can be customized using the following configurable parameters:
 | `pxc.resources.requests`                    | PXC Pods resource requests                                                                                               | `{"memory": "1G", "cpu": "600m"}`|
 | `pxc.resources.limits`                      | PXC Pods resource limits                                                                                                 | `{}`                             |
 | `pxc.sidecars`                              | PXC Pods sidecars                                                                                                        | `[]`                             |
+| `pxc.sidecarVolumes`                        | PXC Pods sidecarVolumes                                                                                                  | `[]`                             |
 | `pxc.sidecarResources.requests`             | PXC sidecar resource requests                                                                                            | `{}`                             |
 | `pxc.sidecarResources.limits`               | PXC sidecar resource limits                                                                                              | `{}`                             |
 | `pxc.nodeSelector`                          | PXC Pods key-value pairs setting for K8S node assingment                                                                 | `{}`                             |
@@ -120,9 +121,10 @@ The chart can be customized using the following configurable parameters:
 | `haproxy.envVarsSecret`           | A secret with environment variables                                          | `` |
 | `haproxy.resources.requests`                     | HAProxy Pods resource requests                                    | `{"memory": "1G", "cpu": "600m"}`                                      |
 | `haproxy.resources.limits`                     | HAProxy Pods resource limits                                    | `{}`                                      |
-| `haproxy.sidecars`                              | HAProxy Pods sidecars                                                                                                        | `[]`                             |
-| `haproxy.sidecarResources.requests`             | HAProxy sidecar resource requests                                                                                            | `{}`                             |
-| `haproxy.sidecarResources.limits`               | HAProxy sidecar resource limits                                                                                              | `{}`                             |
+| `haproxy.sidecars`                              | HAProxy Pods sidecars                                          | `[]`                             |
+| `haproxy.sidecarVolumes`                        | HAProxy Pods sidecarVolumes                                    | `[]`                             |
+| `haproxy.sidecarResources.requests`             | HAProxy sidecar resource requests                              | `{}`                             |
+| `haproxy.sidecarResources.limits`               | HAProxy sidecar resource limits                                | `{}`                             |
 | `haproxy.nodeSelector`                  | HAProxy Pods key-value pairs setting for K8S node assingment                 | `{}`                                      |
 | `haproxy.affinity.antiAffinityTopologyKey` | HAProxy Pods simple scheduling restriction on/off for host, zone, region         | `"kubernetes.io/hostname"` |
 | `haproxy.affinity.advanced` | HAProxy Pods advanced scheduling restriction with match expression engine          | `{}` |
@@ -163,9 +165,10 @@ The chart can be customized using the following configurable parameters:
 | `proxysql.envVarsSecret`           | A secret with environment variables                                           | `` |
 | `proxysql.resources.requests`                     | ProxySQL Pods resource requests                                    | `{"memory": "1G", "cpu": "600m"}`                                      |
 | `proxysql.resources.limits`                     | ProxySQL Pods resource limits                                    | `{}`                                      |
-| `proxysql.sidecars`                              | ProxySQL Pods sidecars                                                                                                        | `[]`                             |
-| `proxysql.sidecarResources.requests`             | ProxySQL sidecar resource requests                                                                                            | `{}`                             |
-| `proxysql.sidecarResources.limits`               | ProxySQL sidecar resource limits                                                                                              | `{}`                             |
+| `proxysql.sidecars`                              | ProxySQL Pods sidecars                                          | `[]`                             |
+| `proxysql.sidecarVolumes`                        | ProxySQL Pods sidecarVolumes                                    | `[]`                             |
+| `proxysql.sidecarResources.requests`             | ProxySQL sidecar resource requests                              | `{}`                             |
+| `proxysql.sidecarResources.limits`               | ProxySQL sidecar resource limits                                | `{}`                             |
 | `proxysql.nodeSelector`                  | ProxySQL Pods key-value pairs setting for K8S node assingment                 | `{}`                                      |
 | `proxysql.affinity.antiAffinityTopologyKey` | ProxySQL Pods simple scheduling restriction on/off for host, zone, region         | `"kubernetes.io/hostname"` |
 | `proxysql.affinity.advanced` | ProxySQL Pods advanced scheduling restriction with match expression engine          | `{}` |

--- a/charts/pxc-db/production-values.yaml
+++ b/charts/pxc-db/production-values.yaml
@@ -87,6 +87,7 @@ pxc:
     limits: {}
   # runtimeClassName: image-rc
   sidecars: []
+  sidecarVolumes: []
   sidecarResources:
     requests: {}
     limits: {}
@@ -240,6 +241,7 @@ haproxy:
       # memory: 1G
       # cpu: 600m
   sidecars: []
+  sidecarVolumes: []
   sidecarResources:
     requests: {}
     limits: {}
@@ -373,6 +375,7 @@ proxysql:
       # memory: 1G
       # cpu: 600m
   sidecars: []
+  sidecarVolumes: []
   sidecarResources:
     requests: {}
     limits: {}

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -342,7 +342,7 @@ spec:
     sidecars:
 {{ $proxysql.sidecars | toYaml | indent 6 }}
     sidecarVolumes:
-{{ $pxc.sidecarVolumes | toYaml | indent 6 }}
+{{ $proxysql.sidecarVolumes | toYaml | indent 6 }}
     sidecarResources:
       requests:
 {{ tpl ($proxysql.sidecarResources.requests | toYaml) $ | indent 8 }}

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -118,6 +118,8 @@ spec:
 {{ tpl ($pxc.resources.limits | toYaml) $ | indent 8 }}
     sidecars:
 {{ $pxc.sidecars | toYaml | indent 6 }}
+    sidecarVolumes:
+{{ $pxc.sidecarVolumes | toYaml | indent 6 }}
     sidecarResources:
       requests:
 {{ tpl ($pxc.sidecarResources.requests | toYaml) $ | indent 8 }}
@@ -238,6 +240,8 @@ spec:
 {{ $haproxy.resources.limits | toYaml | indent 8 }}
     sidecars:
 {{ $haproxy.sidecars | toYaml | indent 6 }}
+    sidecarVolumes:
+{{ $pxc.sidecarVolumes | toYaml | indent 6 }}
     sidecarResources:
       requests:
 {{ tpl ($haproxy.sidecarResources.requests | toYaml) $ | indent 8 }}
@@ -337,6 +341,8 @@ spec:
 {{ $proxysql.resources.limits | toYaml | indent 8 }}
     sidecars:
 {{ $proxysql.sidecars | toYaml | indent 6 }}
+    sidecarVolumes:
+{{ $pxc.sidecarVolumes | toYaml | indent 6 }}
     sidecarResources:
       requests:
 {{ tpl ($proxysql.sidecarResources.requests | toYaml) $ | indent 8 }}

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -241,7 +241,7 @@ spec:
     sidecars:
 {{ $haproxy.sidecars | toYaml | indent 6 }}
     sidecarVolumes:
-{{ $pxc.sidecarVolumes | toYaml | indent 6 }}
+{{ $haproxy.sidecarVolumes | toYaml | indent 6 }}
     sidecarResources:
       requests:
 {{ tpl ($haproxy.sidecarResources.requests | toYaml) $ | indent 8 }}

--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -86,6 +86,7 @@ pxc:
       # cpu: 600m
   # runtimeClassName: image-rc
   sidecars: []
+  sidecarVolumes: []
   sidecarResources:
     requests: {}
     limits: {}
@@ -244,6 +245,7 @@ haproxy:
       # memory: 1G
       # cpu: 600m
   sidecars: []
+  sidecarVolumes: []
   sidecarResources:
     requests: {}
     limits: {}
@@ -375,6 +377,7 @@ proxysql:
       # memory: 1G
       # cpu: 600m
   sidecars: []
+  sidecarVolumes: []
   sidecarResources:
     requests: {}
     limits: {}


### PR DESCRIPTION
Adding sidecarVolume support to the pxc-db, as it is already supported by the pxc-operator

Fixes K8SPXC-1048 (broken StatefulSet due a sidecarVolume)
