### PR TITLE
Add podAnnotations to pxc-operator

### DIFF
--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
       labels:
         app.kubernetes.io/component: operator
         app.kubernetes.io/name: {{ include "pxc-operator.name" . }}

--- a/charts/pxc-operator/values.yaml
+++ b/charts/pxc-operator/values.yaml
@@ -40,3 +40,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+podAnnotations: {}


### PR DESCRIPTION
Would be nice if we could add some annotations to the pxc-operator pod, e.g. `co.elastic.logs/*`

```sh
helm template test . -f values.yaml --set='podAnnotations.co\.elastic\.logs/json\.message_key=msg'
```

```yaml
spec:
[...]
  template:
    metadata:
      annotations:
        co.elastic.logs/json.message_key: msg
```