### PR TITLE
Update NOTES.txt - minor change in getting an ip for LB

### DIFF
--- a/charts/pmm/templates/NOTES.txt
+++ b/charts/pmm/templates/NOTES.txt
@@ -18,7 +18,7 @@ Get the application URL:
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ .Values.service.name }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Values.service.name }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ .Values.service.name }} -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
   echo https://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "pmm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")


### PR DESCRIPTION
Getting IP address in a more canonical way.
Without this change if a loadbalancer has a domain name the current solution does not work well. For example on civo:

```
kubectl get svc --namespace default monitoring-service --template "{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"
ef93d682-24ad-4f95-b765-1a0d198468ee.lb.civo.com212.2.242.224
```

Now it will be like this:
```
kubectl get svc monitoring-service --namespace default -o jsonpath="{.status.loadBalancer.ingress[0].ip}"
212.2.242.224
```