### PR TITLE
fix missing crVersion in the psmdb-db cluster template

### DIFF
--- a/charts/psmdb-db/Chart.yaml
+++ b/charts/psmdb-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.12.0"
 description: A Helm chart for installing Percona Server MongoDB Cluster Databases using the PSMDB Operator.
 name: psmdb-db
 home: https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html
-version: 1.12.4
+version: 1.12.5
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/psmdb-db/templates/cluster.yaml
+++ b/charts/psmdb-db/templates/cluster.yaml
@@ -10,6 +10,7 @@ metadata:
   finalizers:
 {{ .Values.finalizers | toYaml | indent 4 }}
 spec:
+  crVersion: {{ .Values.crVersion }}
   pause: {{ .Values.pause }}
   unmanaged: {{ .Values.unmanaged }}
   {{- if .Values.platform }}

--- a/charts/psmdb-db/values.yaml
+++ b/charts/psmdb-db/values.yaml
@@ -14,7 +14,7 @@ finalizers:
   - delete-psmdb-pods-in-order
 ## Set this if you want to delete database persistent volumes on cluster deletion
   - delete-psmdb-pvc
-crVersion: 1.12.0
+crVersion: 1.12.1
 pause: false
 unmanaged: false
 allowUnsafeConfigurations: false

--- a/charts/psmdb-db/values.yaml
+++ b/charts/psmdb-db/values.yaml
@@ -14,7 +14,7 @@ finalizers:
   - delete-psmdb-pods-in-order
 ## Set this if you want to delete database persistent volumes on cluster deletion
   - delete-psmdb-pvc
-
+crVersion: 1.12.0
 pause: false
 unmanaged: false
 allowUnsafeConfigurations: false

--- a/charts/psmdb-db/values.yaml
+++ b/charts/psmdb-db/values.yaml
@@ -14,7 +14,7 @@ finalizers:
   - delete-psmdb-pods-in-order
 ## Set this if you want to delete database persistent volumes on cluster deletion
   - delete-psmdb-pvc
-crVersion: 1.12.1
+crVersion: 1.12.0
 pause: false
 unmanaged: false
 allowUnsafeConfigurations: false


### PR DESCRIPTION
**Background**
The `crVersion` field should reside in the PSMDB Manifest.
Currently, the template does not contain this field.
the field is used by the PSMDB Operator, for example [here](https://github.com/percona/percona-server-mongodb-operator/blob/98637ec48ea6644f8e320ffd97de19f3fcecbc46/pkg/psmdb/statefulset.go#L224)
and many more cases.
I myself got to the issue since the `isEncryptionEnabled` function was not behaving as expected

**Summary**
- add `crVersion` field to the cluster.yaml `Spec`
- update Chart.yaml version to `version: 1.12.5`
- add default value in values file `crVersion: 1.12.0`
