### PR TITLE
fixed toleration setting pg-db chart

### DIFF
--- a/charts/pg-db/Chart.yaml
+++ b/charts/pg-db/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg-db
 description: 'A Helm chart for Deploying the Percona PostgreSQL database by Percona Distribution for PostgreSQL Operator'
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: 1.3.0
 home: https://github.com/percona/percona-postgresql-operator
 maintainers:

--- a/charts/pg-db/templates/cluster.yaml
+++ b/charts/pg-db/templates/cluster.yaml
@@ -59,7 +59,10 @@ spec:
     resources:
       requests:
         memory: {{ .Values.pgPrimary.resources.requests.memory }}
-    tolerations: {{ .Values.pgPrimary.tolerations }}
+    tolerations:
+{{- if .Values.pgPrimary.tolerations }}
+{{ toYaml .Values.pgPrimary.tolerations | indent 8 }}
+{{- end }}
     volumeSpec:
       size: {{ .Values.pgPrimary.volumeSpec.size }}
       accessmode: {{ .Values.pgPrimary.volumeSpec.accessmode }}


### PR DESCRIPTION
The current template in the pg-db Chart does not allow the user to specify an array for the tolerations. This is necessary to set the effect and the operator. The current setting only allows me to set a string. Example values.yaml:

```
pgPrimary:
  resources:
    requests:
      memory: "1Gi"
  tolerations:
    - key: node.example.com/storage
      effect: NoSchedule
      operator: Exists
  volumeSpec:
    size: 30G
    storageclass: "local-path"
```
