### PR TITLE
CLOUD-758 - Add option to skip SAs and RBAC

### DIFF
--- a/charts/pxc-operator/Chart.yaml
+++ b/charts/pxc-operator/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.12.0
+appVersion: 1.12.1
 description: A Helm chart for deploying the Percona Operator for MySQL (based on Percona XtraDB Cluster)
 name: pxc-operator
 home: https://docs.percona.com/percona-operator-for-mysql/pxc/
-version: 1.12.0
+version: 1.12.1
 maintainers:
   - name: cap1984
     email: ivan.pylypenko@percona.com

--- a/charts/pxc-operator/Chart.yaml
+++ b/charts/pxc-operator/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 1.12.1
+appVersion: 1.12.0
 description: A Helm chart for deploying the Percona Operator for MySQL (based on Percona XtraDB Cluster)
 name: pxc-operator
 home: https://docs.percona.com/percona-operator-for-mysql/pxc/

--- a/charts/pxc-operator/README.md
+++ b/charts/pxc-operator/README.md
@@ -24,18 +24,20 @@ helm install my-operator percona/pxc-operator --version 1.12.0 --namespace my-na
 
 The chart can be customized using the following configurable parameters:
 
-| Parameter                       | Description                                                             | Default                                          |
-| ------------------------------- | ------------------------------------------------------------------------| -------------------------------------------------|
-| `image`                         | PXC Operator Container image full path                                  | `percona/percona-xtradb-cluster-operator:1.12.0` |
-| `imagePullPolicy`               | PXC Operator Container pull policy                                      | `Always`                                         |
-| `imagePullSecrets`              | PXC Operator Pod pull secret                                            | `[]`                                             |
-| `replicaCount`                  | PXC Operator Pod quantity                                               | `1`                                              |
-| `tolerations`                   | List of node taints to tolerate                                         | `[]`                                             |
-| `resources`                     | Resource requests and limits                                            | `{}`                                             |
-| `nodeSelector`                  | Labels for Pod assignment                                               | `{}`                                             |
-| `logStructured`                 | Force PXC operator to print JSON-wrapped log messages                   | `false`                                          |
-| `logLevel`                      | PXC Operator logging level                                              | `INFO`                                           |
-| `disableTelemetry`              | Disable sending PXC Operator telemetry data to Percona                  | `false`                                          |
+| Parameter                       | Description                                                                                    | Default                                          |
+| ------------------------------- | -----------------------------------------------------------------------------------------------| -------------------------------------------------|
+| `image`                         | PXC Operator Container image full path                                                         | `percona/percona-xtradb-cluster-operator:1.12.0` |
+| `imagePullPolicy`               | PXC Operator Container pull policy                                                             | `Always`                                         |
+| `imagePullSecrets`              | PXC Operator Pod pull secret                                                                   | `[]`                                             |
+| `replicaCount`                  | PXC Operator Pod quantity                                                                      | `1`                                              |
+| `tolerations`                   | List of node taints to tolerate                                                                | `[]`                                             |
+| `resources`                     | Resource requests and limits                                                                   | `{}`                                             |
+| `nodeSelector`                  | Labels for Pod assignment                                                                      | `{}`                                             |
+| `logStructured`                 | Force PXC operator to print JSON-wrapped log messages                                          | `false`                                          |
+| `logLevel`                      | PXC Operator logging level                                                                     | `INFO`                                           |
+| `disableTelemetry`              | Disable sending PXC Operator telemetry data to Percona                                         | `false`                                          |
+| `rbac.create`                   | If false RBAC will not be created. RBAC resources will need to be created manually             | `true`                                           |
+| `serviceAccount.create`         | If false the ServiceAccounts will not be created. The ServiceAccounts must be created manually | `true`                                           |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 

--- a/charts/pxc-operator/templates/role-binding.yaml
+++ b/charts/pxc-operator/templates/role-binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -8,6 +9,8 @@ kind: ServiceAccount
 metadata:
   name: percona-xtradb-cluster-operator
 ---
+{{- end }}
+{{- if .Values.rbac.create }}
 {{- if or .Values.watchNamespace .Values.watchAllNamespaces }}
 kind: ClusterRoleBinding
 {{- else }}
@@ -35,3 +38,4 @@ roleRef:
   {{- end }}
   name: {{ include "pxc-operator.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/pxc-operator/templates/role.yaml
+++ b/charts/pxc-operator/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 {{- if or .Values.watchNamespace .Values.watchAllNamespaces }}
 kind: ClusterRole
 {{- else }}
@@ -131,3 +132,4 @@ rules:
   - patch
   - delete
   - deletecollection
+{{- end }}

--- a/charts/pxc-operator/values.yaml
+++ b/charts/pxc-operator/values.yaml
@@ -15,6 +15,16 @@ image: ""
 # set if operator should be deployed in cluster wide mode. defaults to false
 watchAllNamespaces: false
 
+# rbac: settings for deployer RBAC creation
+rbac:
+  # rbac.create: if false RBAC resources should be in place
+  create: true
+
+# serviceAccount: settings for Service Accounts used by the deployer
+serviceAccount:
+  # serviceAccount.create: Whether to create the Service Accounts or not
+  create: true
+
 # set if you want to use a different operator name
 # defaults to `percona-xtradb-cluster-operator`
 # operatorName:


### PR DESCRIPTION
Adds the option to skip ServiceAccounts and RBAC. Similar to how it is done in https://github.com/percona/percona-helm-charts/tree/main/charts/pg-operator