### PR TITLE
Added new variable to enable DBaaS

### DIFF
--- a/charts/pmm/Chart.yaml
+++ b/charts/pmm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pmm
 description: A Helm chart for Percona Monitoring and Management (PMM)
 type: application
-version: 1.2.1
+version: 1.2.2
 appVersion: "2.36.0"
 home: https://github.com/percona/pmm
 maintainers:

--- a/charts/pmm/templates/clusterrolebinding.yaml
+++ b/charts/pmm/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
-{{- if .Values.pmmEnv.ENABLE_DBAAS -}}
+{{- if or (.Values.pmmEnv.ENABLE_DBAAS) (.Values.pmmEnv.DBAAS_ENABLED) -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Context. 

During the provisioning of the k8s cluster on CIVO for the 'DBaaS on the portal demo' feature it fails to provision the cluster because of the following reasons

1. It sees that ENABLE_DBAAS env var is set
2. Tries to provision the cluster
3. Fails because grafana is not ready yet
4. There's no way to restart provisioning from the beginning
5. The end user sees the k8s cluster in the provisioning state

Adding a new env variable for setting ClusterRoleBinding and adding pmm user to cluster-admins will help us because it will be used only to create a correct set of permissions without dealing with PMM.

On the CIVO side we have this API call to enable dbaas once pmm is ready (and grafana is ready too and autoprovisioning will happen shoothly. 