### PR TITLE
K8SPG-402 Remove duplicate "pause" key from cluster.yaml

### DIFF
--- a/charts/pg-db/Chart.yaml
+++ b/charts/pg-db/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg-db
 description: 'A Helm chart for Deploying the Percona PostgreSQL database by Percona Distribution for PostgreSQL Operator'
 type: application
-version: 2.2.0
+version: 2.2.1
 appVersion: 2.2.0
 home: https://docs.percona.com/percona-operator-for-postgresql/2.0/
 maintainers:

--- a/charts/pg-db/templates/cluster.yaml
+++ b/charts/pg-db/templates/cluster.yaml
@@ -20,7 +20,6 @@ spec:
   postgresVersion: {{ .Values.postgresVersion}}
   standby:
     enabled: {{ .Values.standby.enabled }}
-  pause: {{ .Values.pause }}
   {{- if or (.Values.customTLSSecret.name) (.Values.customReplicationTLSSecret.name) }}
   secrets:
     {{- if .Values.customTLSSecret.name }}


### PR DESCRIPTION
Helm install fails with pg-db 2.2.0 due to the existence of a duplicate "pause" key in the cluster.yaml template This PR removes the duplicate.