### PR TITLE
Allow perconapgclusters/finalizers in role

### DIFF
--- a/charts/pg-operator/templates/role.yaml
+++ b/charts/pg-operator/templates/role.yaml
@@ -116,6 +116,7 @@ rules:
   - pgv2.percona.com
   resources:
   - perconapgclusters
+  - perconapgclusters/finalizers
   verbs:
   - create
   - get


### PR DESCRIPTION
Allow perconapgclusters/finalizers to ensure block deletion permissions are granted. This will otherwise cause a apply failure when the operator tries to instantiate a CR on OpenShift 4.10+ (confirmed and tested with this version).

The operator will complain with following error:

`
time="2023-07-12T11:47:18Z" level=error msg="Reconciler error" PerconaPGCluster=pgportal/pgportal-postgresql controller=perconapgcluster controllerGroup=pgv2.percona.com controllerKind=PerconaPGCluster error="update/create PostgresCluster: postgresclusters.postgres-operator.crunchydata.com \"pgportal-postgresql\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>" file="percona/controller/pgcluster/controller.go:243" func="pgcluster.(*PGClusterReconciler).Reconcile" name=pgportal-postgresql namespace=pgportal reconcileID=9d167f6c-d211-426e-8884-7c5159da08ae version=
`