### PR TITLE
K8SPXC-1283 - Update NOTES.txt to correct secret name.

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.13.0
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.13.0
+version: 1.13.1
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/pxc-db/templates/NOTES.txt
+++ b/charts/pxc-db/templates/NOTES.txt
@@ -27,7 +27,7 @@ Join Percona Squad! Get early access to new product features, invite-only ”ask
     kubectl -n {{ .Release.Namespace }} exec -ti \
       {{ include "pxc-database.fullname" . }}-pxc-0 -c pxc -- mysql -uroot -p"$ROOT_PASSWORD"
   {{- else }}
-    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc-database.fullname" . }}-secret -o jsonpath="{.data.root}" | base64 --decode`
+    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc-database.fullname" . }}-secrets -o jsonpath="{.data.root}" | base64 --decode`
     kubectl -n {{ .Release.Namespace }} exec -ti \
       {{ include "pxc-database.fullname" . }}-pxc-0 -c pxc -- mysql -uroot -p"$ROOT_PASSWORD"
   {{- end }}
@@ -38,7 +38,7 @@ Join Percona Squad! Get early access to new product features, invite-only ”ask
   {{- if hasKey .Values.pxc "clusterSecretName" }}
     ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc.clusterSecretName" . }} -o jsonpath="{.data.root}" | base64 --decode`
   {{- else }}
-    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc-database.fullname" . }}-secret -o jsonpath="{.data.root}" | base64 --decode`
+    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc-database.fullname" . }}-secrets -o jsonpath="{.data.root}" | base64 --decode`
   {{- end }}
 
 

--- a/charts/pxc-db/templates/NOTES.txt
+++ b/charts/pxc-db/templates/NOTES.txt
@@ -20,8 +20,6 @@ Join Percona Squad! Get early access to new product features, invite-only ”ask
 
 >>> https://percona.com/k8s <<<
 
-*** Note: if you set customSecretName, replace {{ include "pxc-database.fullname" . }}-secret with the secret name you supplied. ***
-
 1. To get a MySQL prompt inside your new cluster you can run:
 
   {{- if hasKey .Values.pxc "clusterSecretName" }}

--- a/charts/pxc-db/templates/NOTES.txt
+++ b/charts/pxc-db/templates/NOTES.txt
@@ -23,7 +23,7 @@ Join Percona Squad! Get early access to new product features, invite-only ”ask
 1. To get a MySQL prompt inside your new cluster you can run:
 
   {{- if hasKey .Values.pxc "clusterSecretName" }}
-    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc.clusterSecretName" . }} -o jsonpath="{.data.root}" | base64 --decode`
+    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ .Values.pxc.clusterSecretName }} -o jsonpath="{.data.root}" | base64 --decode`
     kubectl -n {{ .Release.Namespace }} exec -ti \
       {{ include "pxc-database.fullname" . }}-pxc-0 -c pxc -- mysql -uroot -p"$ROOT_PASSWORD"
   {{- else }}

--- a/charts/pxc-db/templates/NOTES.txt
+++ b/charts/pxc-db/templates/NOTES.txt
@@ -20,15 +20,30 @@ Join Percona Squad! Get early access to new product features, invite-only ”ask
 
 >>> https://percona.com/k8s <<<
 
+*** Note: if you set customSecretName, replace {{ include "pxc-database.fullname" . }}-secret with the secret name you supplied. ***
+
 1. To get a MySQL prompt inside your new cluster you can run:
 
-    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc-database.fullname" . }} -o jsonpath="{.data.root}" | base64 --decode`
+  {{- if hasKey .Values.pxc "clusterSecretName" }}
+    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc.clusterSecretName" . }} -o jsonpath="{.data.root}" | base64 --decode`
     kubectl -n {{ .Release.Namespace }} exec -ti \
       {{ include "pxc-database.fullname" . }}-pxc-0 -c pxc -- mysql -uroot -p"$ROOT_PASSWORD"
+  {{- else }}
+    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc-database.fullname" . }}-secret -o jsonpath="{.data.root}" | base64 --decode`
+    kubectl -n {{ .Release.Namespace }} exec -ti \
+      {{ include "pxc-database.fullname" . }}-pxc-0 -c pxc -- mysql -uroot -p"$ROOT_PASSWORD"
+  {{- end }}
+
 
 2. To connect an Application running in the same Kubernetes cluster you can connect with:
 
-    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc-database.fullname" . }} -o jsonpath="{.data.root}" | base64 --decode`
+  {{- if hasKey .Values.pxc "clusterSecretName" }}
+    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc.clusterSecretName" . }} -o jsonpath="{.data.root}" | base64 --decode`
+  {{- else }}
+    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc-database.fullname" . }}-secret -o jsonpath="{.data.root}" | base64 --decode`
+  {{- end }}
+
+
 {{- if .Values.proxysql.enabled }}
 
   kubectl run -i --tty --rm percona-client --image=percona --restart=Never \

--- a/charts/pxc-db/templates/NOTES.txt
+++ b/charts/pxc-db/templates/NOTES.txt
@@ -36,7 +36,7 @@ Join Percona Squad! Get early access to new product features, invite-only ”ask
 2. To connect an Application running in the same Kubernetes cluster you can connect with:
 
   {{- if hasKey .Values.pxc "clusterSecretName" }}
-    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc.clusterSecretName" . }} -o jsonpath="{.data.root}" | base64 --decode`
+    ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ .Values.pxc.clusterSecretName }} -o jsonpath="{.data.root}" | base64 --decode`
   {{- else }}
     ROOT_PASSWORD=`kubectl -n {{ .Release.Namespace }} get secrets {{ include "pxc-database.fullname" . }}-secrets -o jsonpath="{.data.root}" | base64 --decode`
   {{- end }}


### PR DESCRIPTION
In this previous PR: https://github.com/percona/percona-helm-charts/commit/fdcb6fbf2da6cf5f2ee92c66f15b9566bcbef03a a change was made to allow the variable "clusterSecretName" to be configured. 

Additionally, if the clusterSecretName wasn't specified, the suffix "-secret" was added to the fullname of the database.

The NOTES.txt was emitting on the fullname and not the fullname-secrets so the instructions would be incorrect in every case.