### PR TITLE
K8SPXC-1291 - Add automatic /tmp mount when readOnlyRootFileSystem is set

### DIFF
--- a/charts/pxc-operator/Chart.yaml
+++ b/charts/pxc-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.13.0
 description: A Helm chart for deploying the Percona Operator for MySQL (based on Percona XtraDB Cluster)
 name: pxc-operator
 home: https://docs.percona.com/percona-operator-for-mysql/pxc/
-version: 1.13.1
+version: 1.13.2
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -88,7 +88,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.containerSecurityContext.readOnlyRootFileSystem }}
+    {{- if .Values.containerSecurityContext.readOnlyRootFilesystem }}
       volumes:
         - name: tmpdir
           emptyDir: {}

--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             protocol: TCP
           command:
           - percona-xtradb-cluster-operator
-          {{- with .Values.containerSecurityContext.readOnlyRootFileSystem }}
+          {{- if .Values.containerSecurityContext.readOnlyRootFilesystem }}
           volumeMounts:
             - name: tmpdir
               mountPath: /tmp

--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -40,6 +40,11 @@ spec:
             protocol: TCP
           command:
           - percona-xtradb-cluster-operator
+          {{- with .Values.containerSecurityContext.readOnlyRootFileSystem }}
+          volumeMounts:
+            - name: tmpdir
+              mountPath: /tmp
+          {{- end }}
           env:
             - name: WATCH_NAMESPACE
               {{- if .Values.watchAllNamespaces }}
@@ -82,6 +87,11 @@ spec:
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.containerSecurityContext.readOnlyRootFileSystem }}
+      volumes:
+        - name: tmpdir
+          emptyDir: {}
     {{- end }}
 {{- if .Values.watchAllNamespaces }}
 ---


### PR DESCRIPTION
When using the container security context _readOnlyRootFileSystem_ the container cannot start because it cannot write to _/tmp_.

This adds an automatic _/tmp_ mount when _readOnlyRootFileSystem_ security context is set.