### PR TITLE
CLOUD-767 - include namespace in metadata for pxc-db and pxc-operator

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.13.0
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.13.1
+version: 1.13.2
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/pxc-db/templates/cluster-secret.yaml
+++ b/charts/pxc-db/templates/cluster-secret.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- else }}
   name: {{ include "pxc-database.fullname" . }}-secrets
   {{- end }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pxc-database.labels" . | indent 4 }}
 type: Opaque

--- a/charts/pxc-db/templates/cluster-ssl-secret.yaml
+++ b/charts/pxc-db/templates/cluster-ssl-secret.yaml
@@ -11,6 +11,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $nameDB }}-ssl
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pxc-database.labels" . | indent 4 }}
 type: kubernetes.io/tls
@@ -28,6 +29,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $nameDB }}-ssl-internal
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pxc-database.labels" . | indent 4 }}
 type: kubernetes.io/tls

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -2,6 +2,7 @@ apiVersion: pxc.percona.com/v1
 kind: PerconaXtraDBCluster
 metadata:
   name: {{ include "pxc-database.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pxc-database.labels" . | indent 4 }}
   finalizers:

--- a/charts/pxc-db/templates/s3-secret.yaml
+++ b/charts/pxc-db/templates/s3-secret.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "pxc-database.fullname" $ }}-s3-{{ $key }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pxc-database.labels" $ | indent 4 }}
 type: Opaque

--- a/charts/pxc-db/values.yaml
+++ b/charts/pxc-db/values.yaml
@@ -582,16 +582,16 @@ backup:
 secrets:
   ## You should be overriding these with your own or specify name for clusterSecretName.
   # passwords:
-  #  root: insecure-root-password
-  #  xtrabackup: insecure-xtrabackup-password
-  #  monitor: insecure-monitor-password
-  #  clustercheck: insecure-clustercheck-password
-  #  proxyadmin: insecure-proxyadmin-password
-  #  pmmserver: insecure-pmmserver-password
-  #  # If pmmserverkey is set in that case pmmserver pass will not be included
-  #  # pmmserverkey: set-pmmserver-api-key
-  #  operator: insecure-operator-password
-  #  replication: insecure-replication-password
+  #   root: insecure-root-password
+  #   xtrabackup: insecure-xtrabackup-password
+  #   monitor: insecure-monitor-password
+  #   clustercheck: insecure-clustercheck-password
+  #   proxyadmin: insecure-proxyadmin-password
+  #   pmmserver: insecure-pmmserver-password
+  #   # If pmmserverkey is set in that case pmmserver pass will not be included
+  #   # pmmserverkey: set-pmmserver-api-key
+  #   operator: insecure-operator-password
+  #   replication: insecure-replication-password
   ## If you are using `cert-manager` you can skip this next section.
   tls: {}
     # This should be the name of a secret that contains certificates.

--- a/charts/pxc-operator/Chart.yaml
+++ b/charts/pxc-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.13.0
 description: A Helm chart for deploying the Percona Operator for MySQL (based on Percona XtraDB Cluster)
 name: pxc-operator
 home: https://docs.percona.com/percona-operator-for-mysql/pxc/
-version: 1.13.2
+version: 1.13.3
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/pxc-operator/templates/deployment.yaml
+++ b/charts/pxc-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "pxc-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pxc-operator.labels" . | indent 4 }}
 spec:

--- a/charts/pxc-operator/templates/role-binding.yaml
+++ b/charts/pxc-operator/templates/role-binding.yaml
@@ -3,11 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "pxc-operator.fullname" . }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: percona-xtradb-cluster-operator
+  namespace: {{ .Release.Namespace }}
 ---
 {{- end }}
 {{- if .Values.rbac.create }}
@@ -21,6 +17,8 @@ metadata:
   name: {{ include "pxc-operator.fullname" . }}
   {{- if .Values.watchNamespace }}
   namespace: {{ .Values.watchNamespace }}
+  {{- else if not .Values.watchAllNamespaces }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
 {{ include "pxc-operator.labels" . | indent 4 }}

--- a/charts/pxc-operator/templates/role.yaml
+++ b/charts/pxc-operator/templates/role.yaml
@@ -7,6 +7,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "pxc-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "pxc-operator.labels" . | indent 4 }}
 rules:


### PR DESCRIPTION
Add namespace information into templates so that they can be used in GitOps way (generate with `helm template` and store in git).

This closes also this PR: https://github.com/percona/percona-helm-charts/pull/241