### PR TITLE
K8SPSMDB-997 - Add serviceAccountName to the existing resources

### DIFF
--- a/charts/psmdb-db/Chart.yaml
+++ b/charts/psmdb-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.14.0"
 description: A Helm chart for installing Percona Server MongoDB Cluster Databases using the PSMDB Operator.
 name: psmdb-db
 home: https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html
-version: 1.14.4
+version: 1.14.5
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/psmdb-db/README.md
+++ b/charts/psmdb-db/README.md
@@ -61,6 +61,7 @@ The chart can be customized using the following configurable parameters:
 | `replsets[0].size`                      | ReplicaSet size (pod quantity)              | `3` |
 | `replsets[0].externalNodes`             | ReplicaSet external nodes (cross cluster replication)           | `[]` |
 | `replsets[0].configuration`             | Custom config for mongod in replica set     | `""` |
+| `replsets[0].serviceAccountName`   | Run replicaset Containers under specified K8S SA              | `""` |
 | `replsets[0].affinity.antiAffinityTopologyKey`   | ReplicaSet Pod affinity              | `kubernetes.io/hostname` |
 | `replsets[0].affinity.advanced`          | ReplicaSet Pod advanced affinity     | `{}` |
 | `replsets[0].tolerations`     | ReplicaSet Pod tolerations                    | `[]` |
@@ -88,6 +89,7 @@ The chart can be customized using the following configurable parameters:
 | `replsets[0].nonvoting.containerSecurityContext` | Set the security context for a Container   | `{}` |
 | `replsets[0].nonvoting.size`           | Number of nonvoting Pods                  | `1` |
 | `replsets[0].nonvoting.configuration`  | Custom config for mongod nonvoting member | `""` |
+| `replsets[0].nonvoting.serviceAccountName`   | Run replicaset nonvoting Container under specified K8S SA              | `""` |
 | `replsets[0].nonvoting.affinity.antiAffinityTopologyKey`   | Nonvoting Pods affinity          | `kubernetes.io/hostname` |
 | `replsets[0].nonvoting.affinity.advanced`          | Nonvoting Pods advanced affinity | `{}` |
 | `replsets[0].nonvoting.tolerations`    | Nonvoting Pod tolerations                 | `[]` |
@@ -109,6 +111,7 @@ The chart can be customized using the following configurable parameters:
 | `replsets[0].nonvoting.volumeSpec.pvc.resources.requests.storage`    | Nonvoting Pods PVC storage size   | `3Gi` |
 | `replsets[0].arbiter.enabled`   | Create MongoDB arbiter service              | `false` |
 | `replsets[0].arbiter.size`   | MongoDB arbiter Pod quantity              | `1` |
+| `replsets[0].arbiter.serviceAccountName`   | Run replicaset arbiter Container under specified K8S SA              | `""` |
 | `replsets[0].arbiter.affinity.antiAffinityTopologyKey`   | MongoDB arbiter Pod affinity              | `kubernetes.io/hostname` |
 | `replsets[0].arbiter.affinity.advanced`          | MongoDB arbiter Pod advanced affinity     | `{}` |
 | `replsets[0].arbiter.tolerations`     | MongoDB arbiter Pod tolerations                | `[]` |
@@ -133,6 +136,7 @@ The chart can be customized using the following configurable parameters:
 | `sharding.configrs.size`                       | Config ReplicaSet size (pod quantity) | `3` |
 | `sharding.configrs.externalNodes`              | Config ReplicaSet external nodes (cross cluster replication)         | `[]` |
 | `sharding.configrs.configuration`              | Custom config for mongod in config replica set | `""` |
+| `sharding.configrs.serviceAccountName`         | Run sharding configrs Containers under specified K8S SA              | `""` |
 | `sharding.configrs.affinity.antiAffinityTopologyKey`    | Config ReplicaSet Pod affinity | `kubernetes.io/hostname` |
 | `sharding.configrs.affinity.advanced`           | Config ReplicaSet Pod advanced affinity | `{}` |
 | `sharding.configrs.tolerations`                | Config ReplicaSet Pod tolerations       | `[]` |
@@ -170,6 +174,7 @@ The chart can be customized using the following configurable parameters:
 | `sharding.configrs.volumeSpec.pvc.resources.requests.storage` | Config ReplicaSet Pods PVC storage size | `3Gi` |
 | `sharding.mongos.size`                         | Mongos size (pod quantity) | `3` |
 | `sharding.mongos.configuration`                | Custom config for mongos   | `""` |
+| `sharding.mongos.serviceAccountName`         | Run sharding mongos Containers under specified K8S SA              | `""` |
 | `sharding.mongos.affinity.antiAffinityTopologyKey`      | Mongos Pods affinity | `kubernetes.io/hostname` |
 | `sharding.mongos.affinity.advanced`             | Mongos Pods advanced affinity | `{}` |
 | `sharding.mongos.tolerations`                  | Mongos Pods tolerations       | `[]` |

--- a/charts/psmdb-db/templates/cluster.yaml
+++ b/charts/psmdb-db/templates/cluster.yaml
@@ -87,6 +87,9 @@ spec:
     configuration: |
 {{ $replset.configuration | indent 6 }}
     {{- end }}
+    {{- if $replset.serviceAccountName }}
+    serviceAccountName: {{ $replset.serviceAccountName }}
+    {{- end }}
     affinity:
 {{ $replset.affinity | toYaml | indent 6 }}
     {{- if $replset.priorityClass }}
@@ -176,6 +179,9 @@ spec:
       configuration: |
 {{ $replset.nonvoting.configuration | indent 8 }}
       {{- end }}
+      {{- if $replset.nonvoting.serviceAccountName }}
+      serviceAccountName: {{ $replset.nonvoting.serviceAccountName }}
+      {{- end }}
       affinity:
 {{ $replset.nonvoting.affinity | toYaml | indent 8 }}
       {{- if $replset.nonvoting.priorityClass }}
@@ -233,6 +239,9 @@ spec:
     arbiter:
       enabled: {{ $replset.arbiter.enabled }}
       size: {{ $replset.arbiter.size }}
+      {{- if $replset.arbiter.serviceAccountName }}
+      serviceAccountName: {{ $replset.arbiter.serviceAccountName }}
+      {{- end }}
       affinity:
 {{ $replset.arbiter.affinity | toYaml | indent 8 }}
       {{- if $replset.arbiter.priorityClass }}
@@ -287,6 +296,9 @@ spec:
       {{- if .Values.sharding.configrs.configuration }}
       configuration: |
 {{ .Values.sharding.configrs.configuration | indent 8 }}
+      {{- end }}
+      {{- if .Values.sharding.configrs.serviceAccountName }}
+      serviceAccountName: {{ .Values.sharding.configrs.serviceAccountName }}
       {{- end }}
       affinity:
 {{ .Values.sharding.configrs.affinity | toYaml | indent 8 }}
@@ -391,6 +403,9 @@ spec:
       {{- if .Values.sharding.mongos.configuration }}
       configuration: |
 {{ .Values.sharding.mongos.configuration | indent 8 }}
+      {{- end }}
+      {{- if .Values.sharding.mongos.serviceAccountName }}
+      serviceAccountName: {{ .Values.sharding.mongos.serviceAccountName }}
       {{- end }}
       affinity:
 {{ .Values.sharding.mongos.affinity | toYaml | indent 8 }}


### PR DESCRIPTION
This is to address issues encountered in the link below. Basically, PSMDBBackup aren't working when using `serviceAccountName` because the entire cluster is using `default`  when using the psmdb-db chart. Since the crd supports serviceAccoountName already, this change adds the ability to set `serviceAccountName` as needed. Ideally, we would want just the specific container to have this kind of access. After some research, it doesn't seem possible to container level service account.

https://forums.percona.com/t/how-to-setup-aws-s3-storage-backup-using-service-account-irsa/21672