### PR TITLE
cloud-831 registry-rollout

### DIFF
--- a/charts/pg-db/Chart.yaml
+++ b/charts/pg-db/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg-db
 description: 'A Helm chart to deploy the PostgreSQL database with the Percona Operator for PostgreSQL'
 type: application
-version: 2.3.0
+version: 2.3.1
 appVersion: 2.3.0
 home: https://docs.percona.com/percona-operator-for-postgresql/2.0/
 maintainers:

--- a/charts/pg-db/values.yaml
+++ b/charts/pg-db/values.yaml
@@ -9,7 +9,7 @@ finalizers:
 #  - percona.com/delete-ssl
 
 crVersion: 2.3.0
-repository: percona/percona-postgresql-operator
+repository: registry-1.percona.com/percona/percona-postgresql-operator
 image: ""
 imagePullPolicy: Always
 postgresVersion: 16


### PR DESCRIPTION
Continue to roll out percona registry for better insights. Applying to PG Operator components.