### PR TITLE
K8SPSMDB-930 - psmdb-operator - Fix watchNamespace

### DIFF
--- a/charts/psmdb-operator/Chart.yaml
+++ b/charts/psmdb-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.15.0"
 description: A Helm chart for deploying the Percona Operator for MongoDB
 name: psmdb-operator
 home: https://docs.percona.com/percona-operator-for-mongodb/
-version: 1.15.2
+version: 1.15.3
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/psmdb-operator/README.md
+++ b/charts/psmdb-operator/README.md
@@ -38,7 +38,8 @@ The chart can be customized using the following configurable parameters:
 | `nodeSelector`                  | Labels for Pod assignment                                                     | `{}`                                      |
 | `podAnnotations`                | Annotations for pod                                                           | `{}`                                      |
 | `podSecurityContext`            | Pod Security Context                                                          | `{}`                                      |
-| `watchNamespace`                | Set when a different from default namespace is needed to watch                | `""`                                      |
+| `watchNamespace`                | Set when a different from default namespace is needed to watch (comma separated if multiple needed)  | `""`               |
+| `createNamespace`               | Set if you want to create watched namespaces with helm                        | `false`                                   |
 | `rbac.create`                   | If false RBAC will not be created. RBAC resources will need to be created manually  | `true`                              |
 | `securityContext`               | Container Security Context                                                    | `{}`                                      |
 | `serviceAccount.create`         | If false the ServiceAccounts will not be created. The ServiceAccounts must be created manually  | `true`                  |

--- a/charts/psmdb-operator/templates/namespace.yaml
+++ b/charts/psmdb-operator/templates/namespace.yaml
@@ -1,8 +1,11 @@
-{{ if .Values.watchNamespace }}
+{{ if and .Values.watchNamespace .Values.createNamespace }}
+{{ range ( split "," .Values.watchNamespace ) }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.watchNamespace }}
+  name: {{ trim . }}
   annotations:
     helm.sh/resource-policy: keep
+---
+{{ end }}
 {{ end }}

--- a/charts/psmdb-operator/templates/role-binding.yaml
+++ b/charts/psmdb-operator/templates/role-binding.yaml
@@ -19,11 +19,9 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: service-account-{{ include "psmdb-operator.fullname" . }}
-  {{- if .Values.watchNamespace }}
-  namespace: {{ .Values.watchNamespace }}
-  {{- else if not .Values.watchAllNamespaces }}
+{{- if not (or .Values.watchNamespace .Values.watchAllNamespaces) }}
   namespace: {{ .Release.Namespace }}
-  {{- end }}
+{{- end }}
   labels:
 {{ include "psmdb-operator.labels" . | indent 4 }}
 subjects:

--- a/charts/psmdb-operator/templates/role.yaml
+++ b/charts/psmdb-operator/templates/role.yaml
@@ -7,7 +7,9 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "psmdb-operator.fullname" . }}
+{{- if not (or .Values.watchNamespace .Values.watchAllNamespaces) }}
   namespace: {{ .Release.Namespace }}
+{{- end }}
   labels:
 {{ include "psmdb-operator.labels" . | indent 4 }}
 rules:

--- a/charts/psmdb-operator/values.yaml
+++ b/charts/psmdb-operator/values.yaml
@@ -17,7 +17,10 @@ disableTelemetry: false
 
 # set if you want to specify a namespace to watch
 # defaults to `.Release.namespace` if left blank
+# multiple namespaces can be specified and separated by comma
 # watchNamespace:
+# set if you want that watched namespaces are created by helm
+# createNamespace: false
 
 # set if operator should be deployed in cluster wide mode. defaults to false
 watchAllNamespaces: false


### PR DESCRIPTION
If we specify `watchNamespace` with multiple namespaces separated with commas namespace creation will fail (because it will try to create namespace `aaa, bbb`) so now we do it in a loop for each specified namespace and only if `createNamespace` is set to `true`.

**Default is now being changed to not create a namespace unless enabled.**