### PR TITLE
K8SPG-524  - pg-db - fix for pgbackrest global section fails to render

### DIFF
--- a/charts/pg-db/Chart.yaml
+++ b/charts/pg-db/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg-db
 description: 'A Helm chart to deploy the PostgreSQL database with the Percona Operator for PostgreSQL'
 type: application
-version: 2.3.5
+version: 2.3.6
 appVersion: 2.3.1
 home: https://docs.percona.com/percona-operator-for-postgresql/2.0/
 maintainers:

--- a/charts/pg-db/templates/cluster.yaml
+++ b/charts/pg-db/templates/cluster.yaml
@@ -268,7 +268,7 @@ spec:
       {{- end }}
       {{- if .Values.backups.pgbackrest.global }}
       global:
-      {{ .Values.backups.pgbackrest.global | toYaml | indent 8 }}
+{{ .Values.backups.pgbackrest.global | toYaml | indent 8 }}
       {{- end }}
       {{- if .Values.backups.pgbackrest.repoHost }}
       repoHost:


### PR DESCRIPTION
Hi,

This PR just fixes indentation issues that  break the use of global section in pgbackrest.
Without this fix you can't setup custom retention rules.

Whenever you add the global section according to the official docs:

```
   global:
       repo1-retention-full: "5"
       repo1-retention-full-type: count
```

The chart errors at the render step with error:

`Error: YAML parse error on pg-db/templates/cluster.yaml: error converting YAML to JSON: yaml: line 78: did not find expected key`

This PR fixes indentation and allows correct rendering of the pgbackrest.global section
