### PR TITLE
[pmm] add extraObjects

### DIFF
--- a/charts/pmm/templates/extraObjects.yaml
+++ b/charts/pmm/templates/extraObjects.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraObjects -}}
+---
+{{- if kindIs "map" . }}
+{{ tpl (toYaml .) $ }}
+{{- else }}
+{{ tpl . $ }}
+{{- end }}
+{{- end }}

--- a/charts/pmm/values.yaml
+++ b/charts/pmm/values.yaml
@@ -265,3 +265,7 @@ extraVolumeMounts: []
 ## @param extraVolumes Optionally specify extra list of additional volumes
 ##
 extraVolumes: []
+## @param extraObjects Optionally specify extra list of additional objects to create
+##
+extraObjects: []
+


### PR DESCRIPTION
add extraObjects

extraObjects can be defined as strings or dictionaries.  string format is useful if the field names are variable, for example...
```
apiVersion: v1
kind: Secret
type: Opaque
data:
  {{- range $key, $value := .Values.someDict }}
    {{ $key }} : {{ b64enc $value }}
  {{- end }}
```
