### PR TITLE
add `annotations` value

### DIFF
--- a/charts/psmdb-db/Chart.yaml
+++ b/charts/psmdb-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.16.0"
 description: A Helm chart for installing Percona Server MongoDB Cluster Databases using the PSMDB Operator.
 name: psmdb-db
 home: https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html
-version: 1.16.0
+version: 1.16.1
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/psmdb-db/README.md
+++ b/charts/psmdb-db/README.md
@@ -36,6 +36,7 @@ The chart can be customized using the following configurable parameters:
 | `unsafeFlags.backupIfUnhealthy` | Allows running backup on a cluster with failed health checks                  | `false`                               |
 | `clusterServiceDNSSuffix`       | The (non-standard) cluster domain to be used as a suffix of the Service name  | `""`                                  |
 | `clusterServiceDNSMode`         | Mode for the cluster service dns (Internal/ServiceMesh)                       | `""`                                  |
+| `annotations`                   | PSMDB custom resource annotations                                             | `{}`                                  |
 | `ignoreAnnotations`             | The list of annotations to be ignored by the Operator                         | `[]`                                  |
 | `ignoreLabels`                  | The list of labels to be ignored by the Operator                              | `[]`                                  |
 | `multiCluster.enabled`          | Enable Multi Cluster Services (MCS) cluster mode                              | `false`                               |

--- a/charts/psmdb-db/templates/cluster.yaml
+++ b/charts/psmdb-db/templates/cluster.yaml
@@ -1,9 +1,10 @@
 apiVersion: psmdb.percona.com/v1
 kind: PerconaServerMongoDB
 metadata:
+  {{- if .Values.annotations }}
   annotations:
-    kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"psmdb.percona.com/v1","kind":"PerconaServerMongoDB"}
+{{ .Values.annotations | toYaml | indent 4 }}
+  {{- end }}
   name: {{ include "psmdb-database.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:

--- a/charts/psmdb-db/values.yaml
+++ b/charts/psmdb-db/values.yaml
@@ -28,6 +28,10 @@ unsafeFlags:
   terminationGracePeriod: false
   backupIfUnhealthy: false
 
+annotations:
+  kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"psmdb.percona.com/v1","kind":"PerconaServerMongoDB"}
+
 # ignoreAnnotations:
 #   - service.beta.kubernetes.io/aws-load-balancer-backend-protocol
 # ignoreLabels:


### PR DESCRIPTION
Add `annotations` value to allow custom annotations on the `PerconaServerMongoDB` resource.