### PR TITLE
K8SPG-602 - pg-operator - Fix Configuration Descriptions in README

### DIFF
--- a/charts/pg-operator/Chart.yaml
+++ b/charts/pg-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg-operator
 description: 'A Helm chart to deploy the Percona Operator for PostgreSQL'
 type: application
-version: 2.3.5
+version: 2.3.6
 appVersion: 2.3.1
 home: https://docs.percona.com/percona-operator-for-postgresql/2.0/
 maintainers:

--- a/charts/pg-operator/README.md
+++ b/charts/pg-operator/README.md
@@ -39,9 +39,9 @@ Chart.
 | `imagePullPolicy` | PG Operator Container pull policy | `Always`|
 | `resources` | Resource requests and limits | `{}` |
 | `nodeSelector` | Labels for Pod assignment | `{}` |
-| `logStructured` | Force PXC operator to print JSON-wrapped log messages | `false` |
-| `logLevel` | PXC Operator logging level | `INFO` |
-| `disableTelemetry` | Disable sending PXC Operator telemetry data to Percona | `false`|
+| `logStructured` | Force PG operator to print JSON-wrapped log messages | `false` |
+| `logLevel` | PG Operator logging level | `INFO` |
+| `disableTelemetry` | Disable sending PG Operator telemetry data to Percona | `false`|
 | `watchNamespace` | Set this variable if the target cluster namespace differs from operators namespace | `` |
 | `watchAllNamespaces` | K8S Cluster-wide operation | `false` |
 


### PR DESCRIPTION
pg-operator README have some configuration descriptions wrongly referencing PXC instead of PG.