### PR TITLE
PSMDB-1492-feature-forcePathStyle

### DIFF
--- a/charts/psmdb-db/Chart.yaml
+++ b/charts/psmdb-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.16.1"
 description: A Helm chart for installing Percona Server MongoDB Cluster Databases using the PSMDB Operator.
 name: psmdb-db
 home: https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html
-version: 1.16.2
+version: 1.16.3
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/psmdb-db/values.yaml
+++ b/charts/psmdb-db/values.yaml
@@ -523,6 +523,8 @@ backup:
     #     credentialsSecret: my-cluster-name-backup-minio
     #     endpointUrl: http://minio.psmdb.svc.cluster.local:9000/minio/
     #     prefix: ""
+    ##    In case of use Swift storage, this flag must be set to true
+    #     forcePathStyle: true
     #   azure-blob:
     #     type: azure
     #     azure:


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PSMDB-1492

https://github.com/percona/percona-helm-charts/issues/347

Hi team, I ran into a problem when tried to deploy psmdb-db chart on my cluster, because I use Swift Storage in openstack, so, Looking at the Percona MongoDB Operator CRD, I notice the CRD supports this parameter, but It was difficult to find, and including this flag on values.yaml, It Worked!
So I believe including that commented on values can be more easily found for someone else trying do deploy the Percona MongoDB in a Kubernetes Cluster running on Openstack environment.

Percona MongoDB CRD where I found the flag: https://github.com/percona/percona-server-mongodb-operator/blob/main/deploy/crd.yaml#L125-L126

It can be added into values.yaml on psmdb-db Chart: https://github.com/percona/percona-helm-charts/blob/main/charts/psmdb-db/values.yaml#L525

```yaml
minio:
  type: s3
  s3:
    bucket: MINIO-BACKUP-BUCKET-NAME-HERE
    region: us-east-1
    credentialsSecret: my-cluster-name-backup-minio
    endpointUrl: http://minio.psmdb.svc.cluster.local:9000/minio/
    prefix: ""
#   In case of use Swift storage, this flag must be set to true
    forcePathStyle: true
```