### PR TITLE
Default network Policy and extraObjects

### DIFF
--- a/charts/psmdb-db/Chart.yaml
+++ b/charts/psmdb-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.16.1"
 description: A Helm chart for installing Percona Server MongoDB Cluster Databases using the PSMDB Operator.
 name: psmdb-db
 home: https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html
-version: 1.16.2
+version: 1.16.3
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/psmdb-db/templates/extraObjects.yaml
+++ b/charts/psmdb-db/templates/extraObjects.yaml
@@ -1,0 +1,9 @@
+{{ range .Values.extraObjects }}
+---
+{{- if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}
+

--- a/charts/psmdb-db/templates/networkPolicy.yaml
+++ b/charts/psmdb-db/templates/networkPolicy.yaml
@@ -1,0 +1,34 @@
+{{ if .Values.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-psmdb-operator
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: {{ .Values.networkPolicy.operatorNamespace }}
+      ports:
+        - port: 27017
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-in-namespace
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      ports:
+        - port: 27017
+{{ end }}

--- a/charts/psmdb-db/values.yaml
+++ b/charts/psmdb-db/values.yaml
@@ -591,3 +591,13 @@ backup:
 #   PMM_SERVER_API_KEY: apikey
 #   # PMM_SERVER_USER: admin
 #   # PMM_SERVER_PASSWORD: admin
+
+networkPolicy:
+  ## Set as psmdb-operator namespace
+  #operatorNamespace: FIXME
+  enabled: false
+
+extraObjects: []
+#  - apiVersion: plop
+#    spec:
+#      foo: bar


### PR DESCRIPTION
The actual chart overlook network policy thus leading to mongo database not being able to reconcile within an environment that uses network policies.

I introduce two netpol : one which allows intra-namespace communication and another one that allows communication between db namespace and operator namespace.

Additionally, there's an extraObjects value that can be used when a use case isn't covered by available values in values file.