### PR TITLE
Allow podAnnotations via helm values for Postgres operator

### DIFF
--- a/charts/pg-operator/Chart.yaml
+++ b/charts/pg-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg-operator
 description: 'A Helm chart to deploy the Percona Operator for PostgreSQL'
 type: application
-version: 2.4.1
+version: 2.4.2
 appVersion: 2.4.1
 home: https://docs.percona.com/percona-operator-for-postgresql/2.0/
 maintainers:

--- a/charts/pg-operator/README.md
+++ b/charts/pg-operator/README.md
@@ -42,6 +42,7 @@ Chart.
 | `logStructured`      | Force PG operator to print JSON-wrapped log messages                               | `false`                                     |
 | `logLevel`           | PG Operator logging level                                                          | `INFO`                                      |
 | `disableTelemetry`   | Disable sending PG Operator telemetry data to Percona                              | `false`                                     |
+| `podAnnotations`     | Add annotations to the Operator Pod                                                | `{}`                                        |
 | `watchNamespace`     | Set this variable if the target cluster namespace differs from operators namespace | ``                                          |
 | `watchAllNamespaces` | K8S Cluster-wide operation                                                         | `false`                                     |
 

--- a/charts/pg-operator/templates/deployment.yaml
+++ b/charts/pg-operator/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/part-of: {{ include "postgres-operator.name" . }}
         pgv2.percona.com/control-plane: postgres-operator
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "postgres-operator.fullname" . }}
     {{- with .Values.imagePullSecrets }}

--- a/charts/pg-operator/values.yaml
+++ b/charts/pg-operator/values.yaml
@@ -37,6 +37,8 @@ tolerations: []
 
 affinity: {}
 
+podAnnotations: {}
+
 # disableTelemetry: according to
 # https://docs.percona.com/percona-operator-for-postgresql/2.0/telemetry.html
 # this is how you can disable telemetry collection


### PR DESCRIPTION
This allows users to set annotations on the pods for example for Prometheus.