### PR TITLE
K8SPG-644 - Fix tolerations iteration issue for pg-db cluster template

### DIFF
--- a/charts/pg-db/templates/cluster.yaml
+++ b/charts/pg-db/templates/cluster.yaml
@@ -222,10 +222,10 @@ spec:
       {{- if $instance.tolerations }}
       tolerations:
       {{- range $toleration :=  $instance.tolerations }}
-      - effect: {{ $toleration.effect }}
-        key: {{ $toleration.key }}
-        operator: {{ $toleration.operator }}
-        value: {{ $toleration.value }}
+        - effect: {{ $toleration.effect }}
+          key: {{ $toleration.key }}
+          operator: {{ $toleration.operator }}
+          value: {{ $toleration.value }}
       {{- end }}
       {{- end }}
 
@@ -356,10 +356,10 @@ spec:
       {{- if .Values.proxy.pgBouncer.tolerations }}
       tolerations:
       {{- range $toleration := .Values.proxy.pgBouncer.tolerations }}
-      - effect: {{ $toleration.effect }}
-        key: {{ $toleration.key }}
-        operator: {{ $toleration.operator }}
-        value: {{ $toleration.value }}
+        - effect: {{ $toleration.effect }}
+          key: {{ $toleration.key }}
+          operator: {{ $toleration.operator }}
+          value: {{ $toleration.value }}
       {{- end }}
       {{- end }}
       {{- if .Values.proxy.pgBouncer.securityContext }}
@@ -414,10 +414,12 @@ spec:
             memory: {{ .Values.backups.pgbackrest.jobs.resources.limits.memory }}
         {{- if .Values.backups.pgbackrest.jobs.tolerations }}
         tolerations:
-        - effect: {{ .Values.backups.pgbackrest.jobs.tolerations.effect }}
-          key: {{ .Values.backups.pgbackrest.jobs.tolerations.key }}
-          operator: {{ .Values.backups.pgbackrest.jobs.tolerations.operator }}
-          value: {{ .Values.backups.pgbackrest.jobs.tolerations.value }}
+        {{- range $toleration := .Values.backups.pgbackrest.jobs.tolerations }}
+          - effect: {{ $toleration.effect }}
+            key: {{ $toleration.key }}
+            operator: {{ $toleration.operator }}
+            value: {{ $toleration.value }}
+        {{- end }}
         {{- end }}
         {{- if .Values.backups.pgbackrest.jobs.securityContext }}
         securityContext: 

--- a/charts/pg-db/templates/cluster.yaml
+++ b/charts/pg-db/templates/cluster.yaml
@@ -221,10 +221,12 @@ spec:
 
       {{- if $instance.tolerations }}
       tolerations:
-      - effect: {{ $instance.tolerations.effect }}
-        key: {{ $instance.tolerations.key }}
-        operator: {{ $instance.tolerations.operator }}
-        value: {{ $instance.tolerations.value }}
+      {{- range $toleration :=  $instance.tolerations }}
+      - effect: {{ $toleration.effect }}
+        key: {{ $toleration.key }}
+        operator: {{ $toleration.operator }}
+        value: {{ $toleration.value }}
+      {{- end }}
       {{- end }}
 
       {{- if $instance.priorityClassName }}
@@ -353,10 +355,12 @@ spec:
       {{- end }}
       {{- if .Values.proxy.pgBouncer.tolerations }}
       tolerations:
-      - effect: {{ .Values.proxy.pgBouncer.tolerations.effect }}
-        key: {{ .Values.proxy.pgBouncer.tolerations.key }}
-        operator: {{ .Values.proxy.pgBouncer.tolerations.operator }}
-        value: {{ .Values.proxy.pgBouncer.tolerations.value }}
+      {{- range $toleration := .Values.proxy.pgBouncer.tolerations }}
+      - effect: {{ $toleration.effect }}
+        key: {{ $toleration.key }}
+        operator: {{ $toleration.operator }}
+        value: {{ $toleration.value }}
+      {{- end }}
       {{- end }}
       {{- if .Values.proxy.pgBouncer.securityContext }}
       securityContext: 


### PR DESCRIPTION
Currently the cluster template incorrectly takes only single value (object) for tolerations instead of accepting an array of objects. 

There is already an issue for this : https://github.com/percona/percona-helm-charts/issues/333
This PR fixes that issue by updating the template code that Instead of replacing with single value, replaces array of tolerations for pg-db cluster template.



