### PR TITLE
fix argo diff in pvc template

### DIFF
--- a/charts/pmm/Chart.yaml
+++ b/charts/pmm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pmm
 description: A Helm chart for Percona Monitoring and Management (PMM)
 type: application
-version: 1.3.19
+version: 1.3.20
 appVersion: "2.43.2"
 home: https://github.com/percona/pmm
 maintainers:

--- a/charts/pmm/templates/statefulset.yaml
+++ b/charts/pmm/templates/statefulset.yaml
@@ -133,7 +133,9 @@ spec:
         {{- toYaml .Values.extraVolumes | nindent 8 }}
       {{- end }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: {{ .Values.storage.name }}
       spec:
         {{- if .Values.storage.selector }}


### PR DESCRIPTION
when deploying in argo the statefulset has a diff since we don't set  the apiVersion and kind fields 
fixes #358