### PR TITLE
github issue 337, added resources block under pmm

### DIFF
--- a/charts/psmdb-db/Chart.yaml
+++ b/charts/psmdb-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.17.0"
 description: A Helm chart for installing Percona Server MongoDB Cluster Databases using the PSMDB Operator.
 name: psmdb-db
 home: https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html
-version: 1.17.0
+version: 1.17.1
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/psmdb-db/templates/cluster.yaml
+++ b/charts/psmdb-db/templates/cluster.yaml
@@ -81,6 +81,10 @@ spec:
     containerSecurityContext:
 {{ .Values.pmm.containerSecurityContext | toYaml | indent 6 }}
     {{- end }}
+    {{- if .Values.pmm.resources }}
+    resources:
+{{ .Values.pmm.resources | toYaml | indent 6 }}
+    {{- end }}
 
   replsets:
   {{- range $k,$replset := .Values.replsets }}


### PR DESCRIPTION
GitHub issue 337, added resources block under pmm to limit resources like CPU and mem and this also helps maintain the QoS of pods. Currently, due to a lack of resources block under PMM, k8s won't ensure Guaranteed QoS for MongoDB pods launched via the Operator through statefulSet. This makes those pods prone to preemption.
This PR should allow QoS to be set for pods as guaranteed and also allow user to limit resources to the PMM container.