### PR TITLE
K8SPSMDB-1184 fixed by adding emptyDir mount at /tmp

### DIFF
--- a/charts/psmdb-operator/Chart.yaml
+++ b/charts/psmdb-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.17.0"
 description: A Helm chart for deploying the Percona Operator for MongoDB
 name: psmdb-operator
 home: https://docs.percona.com/percona-operator-for-mongodb/
-version: 1.17.0
+version: 1.17.1
 maintainers:
   - name: tplavcic
     email: tomislav.plavcic@percona.com

--- a/charts/psmdb-operator/README.md
+++ b/charts/psmdb-operator/README.md
@@ -19,7 +19,7 @@ To install the chart with the `psmdb` release name using a dedicated namespace (
 
 ```sh
 helm repo add percona https://percona.github.io/percona-helm-charts/
-helm install my-operator percona/psmdb-operator --version 1.17.0 --namespace my-namespace
+helm install my-operator percona/psmdb-operator --version 1.17.1 --namespace my-namespace
 ```
 
 The chart can be customized using the following configurable parameters:

--- a/charts/psmdb-operator/templates/deployment.yaml
+++ b/charts/psmdb-operator/templates/deployment.yaml
@@ -53,6 +53,11 @@ spec:
             name: health
           command:
           - percona-server-mongodb-operator
+          {{- if .Values.securityContext.readOnlyRootFilesystem }}
+          volumeMounts:
+            - name: tmpdir
+              mountPath: /tmp
+          {{- end }}
           env:
             - name: LOG_STRUCTURED
               value: "{{ .Values.logStructured }}"
@@ -95,4 +100,9 @@ spec:
     {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.securityContext.readOnlyRootFilesystem }}
+      volumes:
+        - name: tmpdir
+          emptyDir: {}
     {{- end }}


### PR DESCRIPTION
When using the container security context:

```yaml
securityContext:
  readOnlyRootFilesystem: true
```

then the operator fails to reconcile.

This adds an automatic `/tmp` emptyDir mount when `readOnlyRootFilesystem` is set.

This PR is borrowing the implementation from https://github.com/percona/percona-helm-charts/pull/239 but applying it to PSMDB instead of PXC

