### PR TITLE
Skip Everest from automated releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,10 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Remove skipped charts
+        run: |
+          rm -rf charts/everest
+
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
We'd like a separate, manual release process for Everest Helm chart, hence removing it from automated releases