### PR TITLE
EVEREST-1512 | Support for running pre-upgrade checks

### DIFF
--- a/charts/everest/Chart.lock
+++ b/charts/everest/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: common
   repository: file://charts/common
-  version: 0.0.3
+  version: 0.0.4
 - name: everest-db-namespace
   repository: file://charts/everest-db-namespace
   version: 0.0.0
-digest: sha256:99b7426a3f8df9d34dbdc6be2934e6bbde5351b5aa8f0ce4ce78ec18451c8b55
-generated: "2024-10-31T16:32:12.88258+05:30"
+digest: sha256:2b5ec4cba791a9062cafe0a4eced850516b1f28b53b32a2f4a6787e9c941cbee
+generated: "2024-11-05T14:31:28.077684+05:30"

--- a/charts/everest/Makefile
+++ b/charts/everest/Makefile
@@ -17,5 +17,10 @@ release: prepare-chart
 release-dev: IMAGE_PREFIX=perconalab
 release-dev: prepare-chart
 
+deps:
+	helm dependency update .
+	helm dependency update ./charts/everest-db-namespace
+
 docs-gen:
 	docker run --rm -v "$(PWD)/:/helm-docs" -u $(shell id -u) jnorwood/helm-docs:v1.9.1
+

--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -83,3 +83,5 @@ The following table shows the configurable parameters of the Percona Everest cha
 | server.rbac | string | `"g, admin, role:admin\n"` | RBAC policy for Everest. |
 | server.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"20Mi"}}` | Resources to allocate for the server container. |
 | telemetry | bool | `true` | If set, enabled sending telemetry information. |
+| upgrade.preflightChecks | bool | `true` | If set, run preliminary checks before upgrading. It is strongly recommended to enable this setting. |
+| versionMetadataURL | string | `"https://check.percona.com"` | URL of the Version Metadata Service. |

--- a/charts/everest/charts/common/Chart.yaml
+++ b/charts/everest/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for Everest containing common resources.
 type: library
-version: 0.0.3
+version: 0.0.4
 appVersion: "0.0.3"
 maintainers:
   - name: mayankshah1607

--- a/charts/everest/charts/common/Chart.yaml
+++ b/charts/everest/charts/common/Chart.yaml
@@ -3,7 +3,7 @@ name: common
 description: A library chart for Everest containing common resources.
 type: library
 version: 0.0.3
-appVersion: "0.0.2"
+appVersion: "0.0.3"
 maintainers:
   - name: mayankshah1607
     email: mayank.shah@percona.com

--- a/charts/everest/charts/common/README.md
+++ b/charts/everest/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.2](https://img.shields.io/badge/AppVersion-0.0.2-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
 
 A library chart for Everest containing common resources.
 

--- a/charts/everest/charts/common/templates/_db_resources_cleanup.yaml.tpl
+++ b/charts/everest/charts/common/templates/_db_resources_cleanup.yaml.tpl
@@ -9,7 +9,8 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -17,7 +18,8 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
       - everest.percona.com
@@ -35,7 +37,8 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -52,7 +55,7 @@ metadata:
   namespace: {{ .namespace }}
   annotations:
     "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     spec:

--- a/charts/everest/charts/common/templates/_installplan_approver.yaml.tpl
+++ b/charts/everest/charts/common/templates/_installplan_approver.yaml.tpl
@@ -9,7 +9,8 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -17,7 +18,8 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
       - operators.coreos.com
@@ -45,7 +47,8 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -62,7 +65,7 @@ metadata:
   namespace: {{ .namespace }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     spec:

--- a/charts/everest/charts/common/templates/_installplan_approver.yaml.tpl
+++ b/charts/everest/charts/common/templates/_installplan_approver.yaml.tpl
@@ -1,5 +1,5 @@
 #
-# @param .namespace     The namespace where the operator is installed
+# @param .namespace     The namespace where the operators are installed
 #
 {{- define "everest.installplanApprover" }}
 {{- $hookName := "everest-helm-post-install-hook" }}
@@ -9,7 +9,7 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -18,7 +18,7 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -47,7 +47,7 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -64,7 +64,7 @@ metadata:
   name: {{ $hookName }}-{{ randNumeric 6 }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:

--- a/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
+++ b/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
@@ -11,7 +11,7 @@ metadata:
   name: {{ $hookName }}-{{ randNumeric 6 }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook": pre-delete
+    "helm.sh/hook": pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:

--- a/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
+++ b/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
@@ -1,5 +1,6 @@
 #
 # @param .namespace             The namespace where the operator is installed
+# @param .version               Version to upgrade to
 # @param .versionMetadataURL    The URL of the version metadata service
 #
 {{- define "everest.preUpgradeChecks" }}
@@ -24,11 +25,12 @@ spec:
             - |
               OS=$(uname -s | tr '[:upper:]' '[:lower:]')
               ARCH=$(uname -m)
-              VERSION='1.2.0'
+              VERSION={{ .version }}
               apk add --no-cache --quiet curl
               curl -sSL -o everestctl https://github.com/percona/everest/releases/download/v${VERSION}/everestctl-${OS}-${ARCH}
               chmod -R 777 ./everestctl
-                
+              
+              echo "Checking requirements for upgrade to version ${VERSION}"
               ./everestctl upgrade --dry-run --version-metadata-url={{ .versionMetadataURL }}
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure

--- a/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
+++ b/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
@@ -4,42 +4,6 @@
 #
 {{- define "everest.preUpgradeChecks" }}
 {{- $hookName := printf "everest-helm-pre-upgrade-hook" }}
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ $hookName }}
-  namespace: {{ .namespace }}
-  annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ $hookName }}
-  namespace: {{ .namespace }}
-  annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-rules: []
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ $hookName }}
-  namespace: {{ .namespace }}
-  annotations:
-    "helm.sh/hook": pre-delete
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ $hookName }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ $hookName }}
-    namespace: {{ .namespace }}
----
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -64,12 +28,9 @@ spec:
               apk add --no-cache --quiet curl
               curl -sSL -o everestctl https://github.com/percona/everest/releases/download/v${VERSION}/everestctl-${OS}-${ARCH}
               chmod -R 777 ./everestctl
-
+                
               ./everestctl upgrade --dry-run --version-metadata-url={{ .versionMetadataURL }}
       dnsPolicy: ClusterFirst
       restartPolicy: OnFailure
-      serviceAccount: {{ $hookName }}
-      serviceAccountName: {{ $hookName }}
       terminationGracePeriodSeconds: 30
----
 {{- end }}

--- a/charts/everest/charts/everest-db-namespace/Chart.lock
+++ b/charts/everest/charts/everest-db-namespace/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../common
-  version: 0.0.3
-digest: sha256:9c473ddc333f399701ca42304b7c24defb59270a6e04d75254be0ccf6eec438a
-generated: "2024-10-31T15:38:42.331013+05:30"
+  version: 0.0.4
+digest: sha256:d4b492b530b0ae0b3234a3d287a2d3873c99d3dd273c569e82e6eeb83380abc9
+generated: "2024-11-05T14:31:44.457971+05:30"

--- a/charts/everest/charts/everest-db-namespace/Chart.lock
+++ b/charts/everest/charts/everest-db-namespace/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: file://../common
   version: 0.0.3
 digest: sha256:9c473ddc333f399701ca42304b7c24defb59270a6e04d75254be0ccf6eec438a
-generated: "2024-10-31T16:32:16.267628+05:30"
+generated: "2024-10-31T15:38:42.331013+05:30"

--- a/charts/everest/charts/everest-db-namespace/Chart.yaml
+++ b/charts/everest/charts/everest-db-namespace/Chart.yaml
@@ -4,6 +4,7 @@ description: A sub-chart for provisioning Everest DB namespaces.
 type: application
 version: 0.0.0
 appVersion: 0.0.0
+kubeVersion: '>= 1.27.0'
 dependencies:
   - name: common
     version: 0.0.*

--- a/charts/everest/charts/everest-db-namespace/README.md
+++ b/charts/everest/charts/everest-db-namespace/README.md
@@ -15,6 +15,8 @@ A sub-chart for provisioning Everest DB namespaces.
 
 ## Requirements
 
+Kubernetes: `>= 1.27.0`
+
 | Repository | Name | Version |
 |------------|------|---------|
 | file://../common | common | 0.0.* |

--- a/charts/everest/templates/everest-monitoring/hooks.yaml
+++ b/charts/everest/templates/everest-monitoring/hooks.yaml
@@ -1,3 +1,4 @@
+# TODO: We will remove the below hooks once we use the VictoriaMetrics Helm chart directly as a dependency.
 {{- include "everest.csvCleanup" (dict "namespace" .Values.monitoring.namespace) }}
 ---
 {{- include "everest.installplanApprover" (dict "namespace" .Values.monitoring.namespace) }}

--- a/charts/everest/templates/hooks.yaml
+++ b/charts/everest/templates/hooks.yaml
@@ -1,0 +1,3 @@
+{{- if .Values.upgrade.preflightChecks }}
+{{- include "everest.preUpgradeChecks" (dict "namespace" (include "everest.namespace" .) "versionMetadataURL" .Values.versionMetadataServiceURL) }}
+{{- end }}

--- a/charts/everest/templates/hooks.yaml
+++ b/charts/everest/templates/hooks.yaml
@@ -1,3 +1,3 @@
 {{- if .Values.upgrade.preflightChecks }}
-{{- include "everest.preUpgradeChecks" (dict "namespace" (include "everest.namespace" .) "versionMetadataURL" .Values.versionMetadataServiceURL) }}
+{{- include "everest.preUpgradeChecks" (dict "namespace" (include "everest.namespace" .) "versionMetadataURL" .Values.versionMetadataURL) }}
 {{- end }}

--- a/charts/everest/templates/hooks.yaml
+++ b/charts/everest/templates/hooks.yaml
@@ -1,3 +1,3 @@
 {{- if .Values.upgrade.preflightChecks }}
-{{- include "everest.preUpgradeChecks" (dict "namespace" (include "everest.namespace" .) "versionMetadataURL" .Values.versionMetadataURL) }}
+{{- include "everest.preUpgradeChecks" (dict "namespace" (include "everest.namespace" .) "version" .Chart.Version "versionMetadataURL" .Values.versionMetadataURL) }}
 {{- end }}

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -37,6 +37,12 @@ operator:
     requests:
       cpu: 5m
       memory: 64Mi
+# -- URL of the Version Metadata Service.
+versionMetadataServiceURL: "https://check.percona.com"
+upgrade:
+  # -- If set, run preliminary checks before upgrading.
+  # It is strongly recommended to enable this setting.
+  preflightChecks: true
 olm:
   # -- Namespace where OLM is installed. Do no change unless you know what you are doing.
   namespace: everest-olm

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -38,7 +38,7 @@ operator:
       cpu: 5m
       memory: 64Mi
 # -- URL of the Version Metadata Service.
-versionMetadataServiceURL: "https://check.percona.com"
+versionMetadataURL: "https://check.percona.com"
 upgrade:
   # -- If set, run preliminary checks before upgrading.
   # It is strongly recommended to enable this setting.


### PR DESCRIPTION
- Adds a new pre-upgrade hook that runs upgrade checks using `everestctl upgrade --dry-run`
- This hook can be explicitly disabled
- Add some minor improvements to existing hooks to ensure they're cleaned up correctly