### PR TITLE
Add embed.FS for Everest Helm chart

### DIFF
--- a/.github/workflows/everest-pr-checks.yaml
+++ b/.github/workflows/everest-pr-checks.yaml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Basic tests
         run: |
+          helm depencency update
           # Install the chart
           helm install everest-core ./charts/everest --create-namespace --namespace everest-system
 

--- a/.github/workflows/everest-pr-checks.yaml
+++ b/.github/workflows/everest-pr-checks.yaml
@@ -60,9 +60,13 @@ jobs:
         # Only build a kind cluster if there are chart changes to test.
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Build dependencies
+        run: |
+          cd charts/everest
+          make deps
+
       - name: Basic tests
         run: |
-          helm depencency update
           # Install the chart
           helm install everest-core ./charts/everest --create-namespace --namespace everest-system
 

--- a/charts/everest/.helmignore
+++ b/charts/everest/.helmignore
@@ -23,3 +23,6 @@
 .vscode/
 
 Makefile
+go.mod
+go.sum
+helm.go

--- a/charts/everest/go.mod
+++ b/charts/everest/go.mod
@@ -1,3 +1,3 @@
-module github.com/percona/percona-helm-charts/everest
+module github.com/percona/percona-helm-charts/charts/everest
 
 go 1.23.2

--- a/charts/everest/go.mod
+++ b/charts/everest/go.mod
@@ -1,0 +1,3 @@
+module github.com/percona/percona-helm-charts/everest
+
+go 1.23.2

--- a/charts/everest/helm.go
+++ b/charts/everest/helm.go
@@ -1,0 +1,8 @@
+package everest
+
+import "embed"
+
+// Chart contains the Everest Helm chart files.
+//
+//go:embed all:*
+var Chart embed.FS


### PR DESCRIPTION
Since we won't be releasing v0.0.0 Helm chart, the dev-latest builds of the everestctl CLI will use the chart locally from this repo. Placing the chart files inside a embed.FS makes it easier to import these files into the codebase and also version the directory as a dependency.