### PR TITLE
EVEREST-107 | Update flag names in everest-db-namespace chart

### DIFF
--- a/.github/workflows/everest-pr-checks.yaml
+++ b/.github/workflows/everest-pr-checks.yaml
@@ -97,6 +97,11 @@ jobs:
             kubectl wait --for=jsonpath='.status.phase'=Succeeded csv/$csv -n everest --timeout=600s
           done
 
+          # Check DB engines
+          kubectl wait --for=jsonpath='.status.status'=installed dbengine/percona-server-mongodb-operator --timeout=600s -n everest
+          kubectl wait --for=jsonpath='.status.status'=installed dbengine/percona-xtradb-cluster-operator --timeout=600s -n everest
+          kubectl wait --for=jsonpath='.status.status'=installed dbengine/percona-postgresql-operator --timeout=600s -n everest
+
           # Uninstall
           helm uninstall everest -n everest
           kubectl delete ns everest

--- a/charts/everest/charts/everest-db-namespace/README.md
+++ b/charts/everest/charts/everest-db-namespace/README.md
@@ -29,7 +29,7 @@ Kubernetes: `>= 1.27.0`
 | compatibility.openshift | bool | `false` | If set, enable OpenShift compatibility. |
 | namespaceOverride | string | `""` | Namespace override. Defaults to the value of .Release.Namespace. |
 | olm.namespace | string | `"everest-olm"` | Namespace where OLM is installed in the cluster. |
-| pg | bool | `true` | If set, installs the Percona Postgresql Server operator. |
+| postgresql | bool | `true` | If set, installs the Percona Postgresql Server operator. |
 | psmdb | bool | `true` | If set, installs the Percona Server MongoDB operator. |
 | pxc | bool | `true` | If set, installs the Percona XtraDB Cluster operator. |
 | telemetry | bool | `true` | If set, enabled sending telemetry information. |

--- a/charts/everest/charts/everest-db-namespace/templates/pg.subscription.yaml
+++ b/charts/everest/charts/everest-db-namespace/templates/pg.subscription.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pg }}
+{{- if .Values.postgresql }}
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:

--- a/charts/everest/charts/everest-db-namespace/values.yaml
+++ b/charts/everest/charts/everest-db-namespace/values.yaml
@@ -10,7 +10,7 @@ psmdb: true
 # -- If set, installs the Percona XtraDB Cluster operator.
 pxc: true
 # -- If set, installs the Percona Postgresql Server operator.
-pg: true
+postgresql: true
 
 olm:
   # -- Namespace where OLM is installed in the cluster.


### PR DESCRIPTION
Changing `pg` to `postgresql` to maintain consistency with the DBEngine type names. See: https://github.com/percona/everest-operator/blob/main/api/v1alpha1/databaseengine_types.go#L37-L42