### PR TITLE
[EVEREST] Add the ability to set API_REQUESTS_RATE_LIMIT

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -80,7 +80,7 @@ The following table shows the configurable parameters of the Percona Everest cha
 | operator.image | string | `"perconalab/everest-operator"` | Image to use for the Everest operator container. |
 | operator.metricsAddr | string | `"127.0.0.1:8080"` | Metrics address for the operator. |
 | operator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"5m","memory":"64Mi"}}` | Resources to allocate for the operator container. |
-| server.apiRequestsRateLimit | int | `100` | Set the allowed number of requests per minute. |
+| server.apiRequestsRateLimit | int | `100` | Set the allowed number of requests per second. |
 | server.image | string | `"perconalab/everest"` | Image to use for the server container. |
 | server.oidc | object | `{}` | OIDC configuration for Everest. |
 | server.rbac | string | `"g, admin, role:admin\n"` | RBAC policy for Everest. |

--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -80,6 +80,7 @@ The following table shows the configurable parameters of the Percona Everest cha
 | operator.image | string | `"perconalab/everest-operator"` | Image to use for the Everest operator container. |
 | operator.metricsAddr | string | `"127.0.0.1:8080"` | Metrics address for the operator. |
 | operator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"5m","memory":"64Mi"}}` | Resources to allocate for the operator container. |
+| server.apiRequestsRateLimit | int | `100` | Set the allowed number of requests per minute. |
 | server.image | string | `"perconalab/everest"` | Image to use for the server container. |
 | server.oidc | object | `{}` | OIDC configuration for Everest. |
 | server.rbac | string | `"g, admin, role:admin\n"` | RBAC policy for Everest. |

--- a/charts/everest/templates/everest-server/deployment.yaml
+++ b/charts/everest/templates/everest-server/deployment.yaml
@@ -47,3 +47,8 @@ spec:
           volumeMounts:
           - name: jwt-secret
             mountPath: /etc/jwt
+          env:
+          {{- if hasKey .Values.server "apiRequestsRateLimit" }}
+          - name: API_REQUESTS_RATE_LIMIT
+            value: "{{ .Values.server.apiRequestsRateLimit }}"
+          {{- end }}

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -24,7 +24,7 @@ server:
   oidc: {}
   # issuerUrl: ""
   # clientId: ""
-  # -- Set the allowed number of requests per minute.
+  # -- Set the allowed number of requests per second.
   apiRequestsRateLimit: 100
 operator:
   # -- Image to use for the Everest operator container.

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -24,6 +24,8 @@ server:
   oidc: {}
   # issuerUrl: ""
   # clientId: ""
+  # -- Set the allowed number of requests per minute.
+  apiRequestsRateLimit: 100
 operator:
   # -- Image to use for the Everest operator container.
   image: perconalab/everest-operator


### PR DESCRIPTION
* Add the ability to set the `API_REQUESTS_RATE_LIMIT` env var in the Everest Deployment