### PR TITLE
EVEREST-107 | Fix Everest chart kube version

### DIFF
--- a/charts/everest/Chart.yaml
+++ b/charts/everest/Chart.yaml
@@ -4,7 +4,7 @@ description: A cloud-native database platform
 version: 0.0.0
 appVersion: 0.0.0
 type: application
-kubeVersion: '>= 1.27.0'
+kubeVersion: '>= 1.27.0-0'
 maintainers:
   - name: mayankshah1607
     email: mayank.shah@percona.com

--- a/charts/everest/charts/everest-db-namespace/Chart.yaml
+++ b/charts/everest/charts/everest-db-namespace/Chart.yaml
@@ -4,7 +4,7 @@ description: A sub-chart for provisioning Everest DB namespaces.
 type: application
 version: 0.0.0
 appVersion: 0.0.0
-kubeVersion: '>= 1.27.0'
+kubeVersion: '>= 1.27.0-0'
 dependencies:
   - name: common
     version: 0.0.*

--- a/charts/everest/charts/everest-db-namespace/README.md
+++ b/charts/everest/charts/everest-db-namespace/README.md
@@ -15,7 +15,7 @@ A sub-chart for provisioning Everest DB namespaces.
 
 ## Requirements
 
-Kubernetes: `>= 1.27.0`
+Kubernetes: `>= 1.27.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|


### PR DESCRIPTION
Not specifying the meta info results in error on GKE:
```sh
Error: INSTALLATION FAILED: chart requires kubeVersion: >= 1.27.0 which is incompatible with Kubernetes v1.29.10-gke.1071000
```