### PR TITLE
EVEREST | allow specifying initial admin password in values

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -80,6 +80,7 @@ The following table shows the configurable parameters of the Percona Everest cha
 | operator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"5m","memory":"64Mi"}}` | Resources to allocate for the operator container. |
 | server.apiRequestsRateLimit | int | `100` | Set the allowed number of requests per second. |
 | server.image | string | `"perconalab/everest"` | Image to use for the server container. |
+| server.initialAdminPassword | string | `""` | The initial password configured for the admin user. If unset, a random password is generated. It is strongly recommended to reset the admin password after installation. |
 | server.oidc | object | `{}` | OIDC configuration for Everest. |
 | server.rbac | string | `"g, admin, role:admin\n"` | RBAC policy for Everest. |
 | server.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"20Mi"}}` | Resources to allocate for the server container. |

--- a/charts/everest/everest-admin.yaml.tpl
+++ b/charts/everest/everest-admin.yaml.tpl
@@ -1,5 +1,5 @@
 admin:
-  passwordHash: {{ randAlphaNum 64 }}
+  passwordHash: {{ .Values.server.initialAdminPassword | default (randAlphaNum 64) }}
   enabled: true
   capabilities:
     - login

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -26,6 +26,10 @@ server:
   # clientId: ""
   # -- Set the allowed number of requests per second.
   apiRequestsRateLimit: 100
+  # -- The initial password configured for the admin user.
+  # If unset, a random password is generated.
+  # It is strongly recommended to reset the admin password after installation.
+  initialAdminPassword: ""
 operator:
   # -- Image to use for the Everest operator container.
   image: perconalab/everest-operator


### PR DESCRIPTION
Allow specifying the initial admin password with which everest is installed. Defaults to a randow 64 byte string.
This is useful in scenarios where I need to spin up a test installation and don't want to deal with having to retrieve the password. (for example, when using this chart with Tilt, I'd like to always use `admin` as the password)