### PR TITLE
EVEREST-1511 | Allow adding operators to existing DB namespaces

### DIFF
--- a/charts/everest/Chart.lock
+++ b/charts/everest/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: file://charts/common
-  version: 0.0.6
+  version: 0.0.7
 - name: everest-db-namespace
   repository: file://charts/everest-db-namespace
   version: 0.0.0
@@ -11,5 +11,5 @@ dependencies:
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts
   version: 0.37.0
-digest: sha256:2ee205ab871b735bdb62026599e79de9107c72bc95af1bcc4b0cc7442dc47bd6
-generated: "2024-11-19T15:14:18.225172+05:30"
+digest: sha256:0e24635fc89b24d6b214bd9c2f7a0b9e8b8adeeae1cdaa0b24a7b04e93795ec5
+generated: "2024-11-24T00:03:44.414699+05:30"

--- a/charts/everest/Makefile
+++ b/charts/everest/Makefile
@@ -1,6 +1,6 @@
 HELM ?= helm
 
-prepare-chart: deps
+prepare-chart:
 	CHART_FILES="Chart.yaml ./charts/everest-db-namespace/Chart.yaml"; \
 	for chart in $$CHART_FILES; do \
 		yq eval -i '.version = "${VERSION}"' $$chart; \
@@ -10,6 +10,7 @@ prepare-chart: deps
 	yq eval -i '.olm.catalogSourceImage = "$(IMAGE_PREFIX)/everest-catalog"' values.yaml
 	yq eval -i '.operator.image = "$(IMAGE_PREFIX)/everest-operator"' values.yaml
 	yq eval -i '(.dependencies[] | select(.name == "everest-db-namespace")).version = "${VERSION}"' Chart.yaml
+	$(MAKE) deps
 
 release: IMAGE_PREFIX=percona
 release: prepare-chart

--- a/charts/everest/charts/common/Chart.yaml
+++ b/charts/everest/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for Everest containing common resources.
 type: library
-version: 0.0.6
+version: 0.0.7
 appVersion: "0.0.3"
 maintainers:
   - name: mayankshah1607

--- a/charts/everest/charts/common/README.md
+++ b/charts/everest/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
+![Version: 0.0.7](https://img.shields.io/badge/Version-0.0.7-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
 
 A library chart for Everest containing common resources.
 

--- a/charts/everest/charts/common/templates/_operators_installer.yaml.tpl
+++ b/charts/everest/charts/common/templates/_operators_installer.yaml.tpl
@@ -79,9 +79,10 @@ spec:
               subs=$(kubectl -n {{ .namespace }} get subscription -o jsonpath='{.items[*].metadata.name}')
               for sub in $subs
               do
-                subSts=$(kubectl -n {{ .namespace }} get sub $sub -o jsonpath='{.status.state}')
-                if [ "$subSts" = "AtLatestKnown" ]; then
-                  echo "Subscription $sub is at latest known, skip.."
+                # We do not want to touch already installed operators, otherwise bad things can happen.
+                installedCSV=$(kubectl -n {{ .namespace }} get sub $sub -o jsonpath='{.status.installedCSV}')
+                if [ "$installedCSV" != "" ]; then
+                  echo "Operator $sub already installed. Skip..."
                   continue
                 fi
 

--- a/charts/everest/charts/common/templates/_operators_installer.yaml.tpl
+++ b/charts/everest/charts/common/templates/_operators_installer.yaml.tpl
@@ -1,15 +1,15 @@
 #
 # @param .namespace     The namespace where the operators are installed
 #
-{{- define "everest.installplanApprover" }}
-{{- $hookName := "everest-helm-post-install-hook" }}
+{{- define "everest.operatorsInstaller" }}
+{{- $hookName := "everest-operators-installer" }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -18,7 +18,7 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 rules:
   - apiGroups:
@@ -47,7 +47,7 @@ metadata:
   name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -61,10 +61,10 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ $hookName }}-{{ randNumeric 6 }}
+  name: {{ $hookName }}
   namespace: {{ .namespace }}
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
@@ -79,6 +79,12 @@ spec:
               subs=$(kubectl -n {{ .namespace }} get subscription -o jsonpath='{.items[*].metadata.name}')
               for sub in $subs
               do
+                subSts=$(kubectl -n {{ .namespace }} get sub $sub -o jsonpath='{.status.state}')
+                if [ "$subSts" = "AtLatestKnown" ]; then
+                  echo "Subscription $sub is at latest known, skip.."
+                  continue
+                fi
+
                 echo "Waiting for InstallPlan to be created for Subscription $sub"
                 kubectl wait --for=jsonpath='.status.installplan.name' sub/$sub -n {{ .namespace }} --timeout=600s
                 

--- a/charts/everest/charts/everest-db-namespace/Chart.lock
+++ b/charts/everest/charts/everest-db-namespace/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../common
-  version: 0.0.6
-digest: sha256:7505f41c0cd8fa47b4b8f086f5581e421f7830376d8535e8aeaab13436a50f09
-generated: "2024-11-19T13:43:21.503125+05:30"
+  version: 0.0.7
+digest: sha256:b587c94535fc460b32a91f347f4783e9bbcda30890852d7a9527a334221418b9
+generated: "2024-11-24T00:03:48.771339+05:30"

--- a/charts/everest/charts/everest-db-namespace/templates/hooks.yaml
+++ b/charts/everest/charts/everest-db-namespace/templates/hooks.yaml
@@ -1,6 +1,6 @@
 {{- include "everest.csvCleanup" (dict "namespace" (include "db.namespace" .)) }}
 ---
-{{- include "everest.installplanApprover" (dict "namespace" (include "db.namespace" .)) }}
+{{- include "everest.operatorsInstaller" (dict "namespace" (include "db.namespace" .)) }}
 ---
 {{ if .Values.cleanupOnUninstall }}
 {{- include "everest.dbResourcesCleanup" (dict "namespace" (include "db.namespace" .)) }}

--- a/charts/everest/charts/everest-db-namespace/templates/operatorgroup.yaml
+++ b/charts/everest/charts/everest-db-namespace/templates/operatorgroup.yaml
@@ -1,7 +1,7 @@
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: database-operators
+  name: everest-databases
   namespace: {{ include "db.namespace" . }}
 spec:
   targetNamespaces:


### PR DESCRIPTION
* Earlier it was not possible to add more operator installations on existing DB namespaces. This is because the installplan hook ran only once, during installation (i.e, in the post-install step)
* Since you'd have to run `helm update ..` to modify an existing helm release (to add more operator installations), this PR updates the chart hook to also run on post-upgrade
* Adds an additional check to not handle the InstallPlans of installed Subscriptions
* Also uses a more generic name for the chart hook
* Revert the operatorgroup name - use the one originally used in Everest, otherwise upgrading on existing installation breaks