### PR TITLE
EVEREST-107 | Update selector override for kube-state-metrics

### DIFF
--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -83,6 +83,8 @@ everest-db-namespace:
 kube-state-metrics:
   enabled: true
   namespaceOverride: "everest-monitoring"
+  selectorOverride:
+    app.kubernetes.io/name: kube-state-metrics
   customLabels:
     everest.percona.com/type: monitoring
   fullnameOverride: kube-state-metrics


### PR DESCRIPTION
* This is done in order to maintain backward compatibility with the existing kube-state-metrics installation provided by Everest
* Since we cannot change the overrides of an existing deployment, we need to ensure that selector overrides do not change, else Helm upgrade fails