### PR TITLE
EVEREST-107 | Secrets and ConfigMaps should not be updated during upgrades

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -82,9 +82,11 @@ The following table shows the configurable parameters of the Percona Everest cha
 | server.apiRequestsRateLimit | int | `100` | Set the allowed number of requests per second. |
 | server.image | string | `"perconalab/everest"` | Image to use for the server container. |
 | server.initialAdminPassword | string | `""` | The initial password configured for the admin user. If unset, a random password is generated. It is strongly recommended to reset the admin password after installation. |
-| server.oidc | object | `{}` | OIDC configuration for Everest. The config specified here is applied during installation only. During upgrades, the existing config is preserved. To change the config after installation, you need to manually manage the `everest-settigs` ConfigMap. |
+| server.jwtKey | string | `""` | Key for signing JWT tokents. This needs to be an RSA private key. This is created during installation only. To update the key after installation, you need to manually update the `everest-jwt` Secret or use everestctl. |
+| server.oidc | object | `{}` | OIDC configuration for Everest. These settings are applied during installation only. To change the settings after installation, you need to manually update the `everest-settings` ConfigMap. |
+| server.rbac | object | `{"enabled":false,"policy":"g, admin, role:admin\n"}` | Settings for RBAC. These settings are applied during installation only. To change the settings after installation, you need to manually update the `everest-rbac` ConfigMap. |
 | server.rbac.enabled | bool | `false` | If set, enables RBAC for Everest. |
-| server.rbac.policy | string | `"g, admin, role:admin\n"` | RBAC policy configuration. Ignored if `rbac.enabled` is false. The policy specified here is applied during installation only. During upgrades, the existing policy is preserved. To change the policy after installation, you need to manually manage the `everest-rbac` ConfigMap. |
+| server.rbac.policy | string | `"g, admin, role:admin\n"` | RBAC policy configuration. Ignored if `rbac.enabled` is false. |
 | server.resources | object | `{"limits":{"cpu":"200m","memory":"500Mi"},"requests":{"cpu":"100m","memory":"20Mi"}}` | Resources to allocate for the server container. |
 | telemetry | bool | `true` | If set, enabled sending telemetry information. |
 | upgrade.preflightChecks | bool | `true` | If set, run preliminary checks before upgrading. It is strongly recommended to enable this setting. |

--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -82,7 +82,7 @@ The following table shows the configurable parameters of the Percona Everest cha
 | server.apiRequestsRateLimit | int | `100` | Set the allowed number of requests per second. |
 | server.image | string | `"perconalab/everest"` | Image to use for the server container. |
 | server.initialAdminPassword | string | `""` | The initial password configured for the admin user. If unset, a random password is generated. It is strongly recommended to reset the admin password after installation. |
-| server.jwtKey | string | `""` | Key for signing JWT tokents. This needs to be an RSA private key. This is created during installation only. To update the key after installation, you need to manually update the `everest-jwt` Secret or use everestctl. |
+| server.jwtKey | string | `""` | Key for signing JWT tokens. This needs to be an RSA private key. This is created during installation only. To update the key after installation, you need to manually update the `everest-jwt` Secret or use everestctl. |
 | server.oidc | object | `{}` | OIDC configuration for Everest. These settings are applied during installation only. To change the settings after installation, you need to manually update the `everest-settings` ConfigMap. |
 | server.rbac | object | `{"enabled":false,"policy":"g, admin, role:admin\n"}` | Settings for RBAC. These settings are applied during installation only. To change the settings after installation, you need to manually update the `everest-rbac` ConfigMap. |
 | server.rbac.enabled | bool | `false` | If set, enables RBAC for Everest. |

--- a/charts/everest/templates/everest-server/accounts.secret.yaml
+++ b/charts/everest/templates/everest-server/accounts.secret.yaml
@@ -14,6 +14,7 @@ metadata:
     {{ $key }}: "{{ $value }}"
   {{- end }}
   {{- end }}
+    helm.sh/resource-policy: keep
 data:
   {{- if not $secret }}
   users.yaml: {{ tpl (.Files.Get "everest-admin.yaml.tpl") . | b64enc }}

--- a/charts/everest/templates/everest-server/accounts.secret.yaml
+++ b/charts/everest/templates/everest-server/accounts.secret.yaml
@@ -1,23 +1,12 @@
-{{- $secretName := (printf "everest-accounts") -}}
-{{- $secret := (lookup "v1" "Secret" (include "everest.namespace" .) $secretName ) -}}
+{{- if .Release.IsInstall }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: "everest-accounts"
   namespace: {{ include  "everest.namespace" . }}
   annotations:
-  {{- if not $secret }}
     insecure-password/admin: "true"
-  {{- else }}
-  {{- range $key, $value := $secret.metadata.annotations }}
-    {{ $key }}: "{{ $value }}"
-  {{- end }}
-  {{- end }}
+    helm.sh/resource-policy: keep
 data:
-  {{- if not $secret }}
   users.yaml: {{ tpl (.Files.Get "everest-admin.yaml.tpl") . | b64enc }}
-  {{- else }}
-  {{- range $key, $value := $secret.data }}
-  {{ $key }}: {{ $value }}
-  {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/everest/templates/everest-server/accounts.secret.yaml
+++ b/charts/everest/templates/everest-server/accounts.secret.yaml
@@ -1,12 +1,23 @@
 {{- if .Release.IsInstall }}
+{{- $secretName := (printf "everest-accounts") -}}
+{{- $secret := (lookup "v1" "Secret" (include "everest.namespace" .) $secretName ) -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "everest-accounts"
+  name: {{ $secretName }}
   namespace: {{ include  "everest.namespace" . }}
   annotations:
+  {{- if not $secret }}
     insecure-password/admin: "true"
-    helm.sh/resource-policy: keep
+  {{- else }}
+  {{- range $key, $value := $secret.metadata.annotations }}
+    {{ $key }}: "{{ $value }}"
+  {{- end }}
+  {{- end }}
 data:
+  {{- if not $secret }}
   users.yaml: {{ tpl (.Files.Get "everest-admin.yaml.tpl") . | b64enc }}
+  {{- else }}
+  users.yaml: {{ index $secret.data "users.yaml" }}
+  {{- end }}
 {{- end }}

--- a/charts/everest/templates/everest-server/jwt.secret.yaml
+++ b/charts/everest/templates/everest-server/jwt.secret.yaml
@@ -1,15 +1,11 @@
-{{- $secretName := (printf "everest-jwt") -}}
-{{- $secret := (lookup "v1" "Secret" (include "everest.namespace" .) $secretName ) -}}
+{{- if .Release.IsInstall }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: "everest-jwt"
   namespace: {{ include  "everest.namespace" . }}
+  annotations:
+    helm.sh/resource-policy: keep
 data:
-  {{- if not $secret }}
   id_rsa: {{ genPrivateKey "rsa" | b64enc  }}
-  {{- else }}
-  {{- range $key, $value := $secret.data }}
-  {{ $key }}: {{ $value }}
-  {{- end }}
-  {{- end }}
+{{- end }}

--- a/charts/everest/templates/everest-server/jwt.secret.yaml
+++ b/charts/everest/templates/everest-server/jwt.secret.yaml
@@ -7,5 +7,5 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
 data:
-  id_rsa: {{ genPrivateKey "rsa" | b64enc  }}
+  id_rsa: {{ .Values.server.jwtKey | default (genPrivateKey "rsa") | b64enc  }}
 {{- end }}

--- a/charts/everest/templates/everest-server/rbac.configmap.yaml
+++ b/charts/everest/templates/everest-server/rbac.configmap.yaml
@@ -1,17 +1,13 @@
-{{- $cmName := (printf "everest-rbac") -}}
-{{- $cm := (lookup "v1" "ConfigMap" (include "everest.namespace" .) $cmName ) -}}
+{{- if .Release.IsInstall }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $cmName }}
+  name: "everest-rbac"
   namespace: {{ include  "everest.namespace" . }}
+  annotations:
+    helm.sh/resource-policy: keep
 data:
-  {{- if or (not $cm) .Release.IsInstall }}
   enabled: {{ .Values.server.rbac.enabled | default "false" | quote }}
   policy.csv: |
     {{- .Values.server.rbac.policy | nindent 4 }}
-  {{- else }}
-  enabled: {{ $cm.data.enabled | default "false" | quote }}
-  policy.csv: |
-    {{- index $cm.data "policy.csv" | default "" | nindent 4 }}
-  {{- end }}
+{{- end }}

--- a/charts/everest/templates/everest-server/rbac.configmap.yaml
+++ b/charts/everest/templates/everest-server/rbac.configmap.yaml
@@ -11,7 +11,7 @@ data:
   policy.csv: |
     {{- .Values.server.rbac.policy | nindent 4 }}
   {{- else }}
-  {{- range $key, $value := $cm.data }}
-  {{ $key }}: {{ $value }}
-  {{- end }}
+  enabled: {{ $cm.data.enabled | default "false" | quote }}
+  policy.csv: |
+    {{- index $cm.data "policy.csv" | default "" | nindent 4 }}
   {{- end }}

--- a/charts/everest/templates/everest-server/settings.configmap.yaml
+++ b/charts/everest/templates/everest-server/settings.configmap.yaml
@@ -1,19 +1,15 @@
-{{- $cmName := (printf "everest-settings") -}}
-{{- $cm := (lookup "v1" "ConfigMap" (include "everest.namespace" .) $cmName ) -}}
+{{- if .Release.IsInstall }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $cmName }}
+  name: "everest-settings"
   namespace: {{ include  "everest.namespace" . }}
+  annotations:
+    helm.sh/resource-policy: keep
 data:
-  {{- if or (not $cm) .Release.IsInstall }}
   {{- if .Values.server.oidc }}
   oidc.config: |
     {{- toYaml .Values.server.oidc | nindent 4 }}
   {{- end }}
-  {{- else }}
-  {{- range $key, $value := $cm.data }}
-  {{ $key }}: {{ $value }}
-  {{- end }}
-  {{- end }}
+{{- end }}
 

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -17,6 +17,8 @@ server:
     requests:
       cpu: 100m
       memory: 20Mi
+  # -- RSA private key for JWT signing.
+  jwtKey: ""
   rbac:
     # -- If set, enables RBAC for Everest.
     enabled: false

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -17,19 +17,22 @@ server:
     requests:
       cpu: 100m
       memory: 20Mi
-  # -- RSA private key for JWT signing.
+  # -- Key for signing JWT tokents. This needs to be an RSA private key.
+  # This is created during installation only.
+  # To update the key after installation, you need to manually update the `everest-jwt` Secret or use everestctl.
   jwtKey: ""
+  # -- Settings for RBAC.
+  # These settings are applied during installation only.
+  # To change the settings after installation, you need to manually update the `everest-rbac` ConfigMap.
   rbac:
     # -- If set, enables RBAC for Everest.
     enabled: false
     # -- RBAC policy configuration. Ignored if `rbac.enabled` is false.
-    # The policy specified here is applied during installation only. During upgrades, the existing policy is preserved.
-    # To change the policy after installation, you need to manually manage the `everest-rbac` ConfigMap.
     policy: |
       g, admin, role:admin
   # -- OIDC configuration for Everest.
-  # The config specified here is applied during installation only. During upgrades, the existing config is preserved.
-  # To change the config after installation, you need to manually manage the `everest-settigs` ConfigMap.
+  # These settings are applied during installation only.
+  # To change the settings after installation, you need to manually update the `everest-settings` ConfigMap.
   oidc: {}
   # issuerUrl: ""
   # clientId: ""

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -17,7 +17,7 @@ server:
     requests:
       cpu: 100m
       memory: 20Mi
-  # -- Key for signing JWT tokents. This needs to be an RSA private key.
+  # -- Key for signing JWT tokens. This needs to be an RSA private key.
   # This is created during installation only.
   # To update the key after installation, you need to manually update the `everest-jwt` Secret or use everestctl.
   jwtKey: ""


### PR DESCRIPTION
Fix how the Helm chart preserves Secrets and ConfigMaps during upgrades:

* The ConfigMaps and secrets need to be preserved during upgrades since they may be modified externally (via Kubectl or everestctl), and we currently do not recommend one particular way to managed them
* In the current logic, the Helm template would simply get the existing resources, iterate over the `data` key-value pairs and append them to the current template. This however does not work correctly if there are, for example, multi-line values (like in RBAC configmap, settings ConfigMap), or bools converted to strings (like `enabled`)
* The updated logic is simplified. We will include the manifest only during installs by checking `.Release.IsInstall`. However, Helm will then remove the manifests during upgrade. To tackle this, we will add the `resource-policy: keep` annotation.
* This creates one limitation - these resources will stay after the Chart is uninstalled. However, we expect the user to delete the namespace manually.