### PR TITLE
EVEREST-107 Remove kube-rbac-proxy and update kubebuilder project to go/v4

### DIFF
--- a/charts/everest/templates/everest-operator/backupstorage-editor.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/backupstorage-editor.clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-backupstorage-editor-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - backupstorages
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - backupstorages/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/backupstorage-viewer.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/backupstorage-viewer.clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-backupstorage-viewer-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - backupstorages
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - backupstorages/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/databasecluster-editor.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/databasecluster-editor.clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-databasecluster-editor-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusters/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/databasecluster-viewer.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/databasecluster-viewer.clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-databasecluster-viewer-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusters/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/databaseclusterbackup-editor.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/databaseclusterbackup-editor.clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-databaseclusterbackup-editor-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusterbackups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusterbackups/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/databaseclusterbackup-viewer.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/databaseclusterbackup-viewer.clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-databaseclusterbackup-viewer-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusterbackups
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusterbackups/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/databaseclusterrestore-editor.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/databaseclusterrestore-editor.clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-databaseclusterrestore-editor-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusterrestores
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusterrestores/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/databaseclusterrestore-viewer.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/databaseclusterrestore-viewer.clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-databaseclusterrestore-viewer-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusterrestores
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseclusterrestores/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/databaseengine-editor.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/databaseengine-editor.clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-databaseengine-editor-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseengines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseengines/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/databaseengine-viewer.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/databaseengine-viewer.clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-databaseengine-viewer-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseengines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - databaseengines/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/deployment.yaml
+++ b/charts/everest/templates/everest-operator/deployment.yaml
@@ -19,54 +19,11 @@ spec:
       labels:
         app: everest-operator
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: kubernetes.io/arch
-                operator: In
-                values:
-                - amd64
-                - arm64
-                - ppc64le
-                - s390x
-              - key: kubernetes.io/os
-                operator: In
-                values:
-                - linux
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
-        imagePullPolicy: IfNotPresent
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-      - args:
-        - --health-probe-bind-address={{ .Values.operator.healthProbeAddr }}
-        - --metrics-bind-address={{ .Values.operator.metricsAddr }}
-        {{- if .Values.operator.enableLeaderElection }}
+        - --metrics-bind-address=:8443
         - --leader-elect
+        - --health-probe-bind-address=:8081
         {{- end }}
         - --monitoring-namespace={{ .Values.monitoring.namespaceOverride }}
         - --system-namespace={{ include  "everest.namespace" . }}

--- a/charts/everest/templates/everest-operator/deployment.yaml
+++ b/charts/everest/templates/everest-operator/deployment.yaml
@@ -21,10 +21,11 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-bind-address=:8443
+        {{- if .Values.operator.enableLeaderElection }}
         - --leader-elect
-        - --health-probe-bind-address=:8081
         {{- end }}
+        - --metrics-bind-address=:8443
+        - --health-probe-bind-address=:8081
         - --monitoring-namespace={{ .Values.monitoring.namespaceOverride }}
         - --system-namespace={{ include  "everest.namespace" . }}
         command:

--- a/charts/everest/templates/everest-operator/metrics-auth.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/metrics-auth.clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: everest-operator-proxy-role
+  name: everest-operator-metrics-auth-role
 rules:
 - apiGroups:
   - authentication.k8s.io

--- a/charts/everest/templates/everest-operator/metrics-auth.clusterrolebinding.yaml
+++ b/charts/everest/templates/everest-operator/metrics-auth.clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: everest-operator-proxy-rolebinding
+  name: everest-operator-metrics-auth-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: everest-operator-proxy-role
+  name: everest-operator-metrics-auth-role
 subjects:
 - kind: ServiceAccount
   name: everest-operator-controller-manager

--- a/charts/everest/templates/everest-operator/metrics.service.yaml
+++ b/charts/everest/templates/everest-operator/metrics.service.yaml
@@ -12,7 +12,7 @@ spec:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8443
   selector:
     app: everest-operator
   sessionAffinity: None

--- a/charts/everest/templates/everest-operator/monitoringconfig-editor.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/monitoringconfig-editor.clusterrole.yaml
@@ -1,0 +1,23 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-monitoringconfig-editor-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - monitoringconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - monitoringconfigs/status
+  verbs:
+  - get

--- a/charts/everest/templates/everest-operator/monitoringconfig-viewer.clusterrole.yaml
+++ b/charts/everest/templates/everest-operator/monitoringconfig-viewer.clusterrole.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: everest-operator-monitoringconfig-viewer-role
+rules:
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - monitoringconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - everest.percona.com
+  resources:
+  - monitoringconfigs/status
+  verbs:
+  - get


### PR DESCRIPTION
In https://github.com/percona/everest-operator/pull/597 we removed kube-rbac-proxy and migrated to go/v4 project. This commit reflects the manifest changes introduced in that PR.