### PR TITLE
EVEREST-1732 | Fix pre-delete hook (DB resource cleanup)

### DIFF
--- a/charts/everest/Chart.lock
+++ b/charts/everest/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: file://charts/common
-  version: 0.0.8
+  version: 0.0.9
 - name: everest-db-namespace
   repository: file://charts/everest-db-namespace
   version: 0.0.0
@@ -11,5 +11,5 @@ dependencies:
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts
   version: 0.37.0
-digest: sha256:71d9bb022981ea8e742d0598b558b3cb220cec141bbeafb2fdfaf2c3577f79ed
-generated: "2024-11-25T15:55:22.905234+05:30"
+digest: sha256:8a1adcd2e53bc836e6a7a238a85abb4e751de72dc83eef33829c8a1bc548c7af
+generated: "2024-12-09T21:17:34.358806+05:30"

--- a/charts/everest/charts/common/Chart.yaml
+++ b/charts/everest/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for Everest containing common resources.
 type: library
-version: 0.0.8
+version: 0.0.9
 appVersion: "0.0.3"
 maintainers:
   - name: mayankshah1607

--- a/charts/everest/charts/common/README.md
+++ b/charts/everest/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
 
 A library chart for Everest containing common resources.
 

--- a/charts/everest/charts/common/templates/_db_resources_cleanup.yaml.tpl
+++ b/charts/everest/charts/common/templates/_db_resources_cleanup.yaml.tpl
@@ -11,6 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -20,6 +21,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
 rules:
   - apiGroups:
       - everest.percona.com
@@ -28,8 +30,10 @@ rules:
       - backupstorages
       - monitoringconfigs
     verbs:
+      - get
       - delete
       - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -39,6 +43,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -56,6 +61,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1"
 spec:
   template:
     spec:
@@ -64,7 +70,8 @@ spec:
           name: {{ $hookName }}
           command:
             - /bin/sh
-            - -c
+            - -ec
+          args:
             - |
               echo "Deleting DatabaseClusters"
               kubectl delete databaseclusters -n {{ .namespace }} --all --wait

--- a/charts/everest/charts/everest-db-namespace/Chart.lock
+++ b/charts/everest/charts/everest-db-namespace/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../common
-  version: 0.0.8
-digest: sha256:13f798bb1de3463785dcfa1cd3f535d09789cad1c7f2b33062efc11bfec76f8c
-generated: "2024-11-25T15:55:26.288596+05:30"
+  version: 0.0.9
+digest: sha256:9556a266d6497f3284b4df070b840145be1bff3c5ee235f81bf4a7973780e0d0
+generated: "2024-12-09T21:17:37.704211+05:30"


### PR DESCRIPTION
- update the Job RBAC so that `--wait` works correctly. Currently, without the `get` and `watch` permissions, `--wait` doesn't actually wait for the deletion and fails silently
- add appropriate hook weight so that the DB clean-up always runs first