### PR TITLE
EVEREST-107 | add note for upgrade

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -115,7 +115,7 @@ helm upgrade everest percona/everest-db-namespace --namespace [DB NAMESPACE] --v
 
 Notes:
 * :warning: When specifying values during an upgrade (i.e, using `--set`, `--set-json`, `--values`, etc.), Helm resets all the other values
-to the defaults built into the chart. To preserve the previously set values, you must use the `--reuse-flag`.
+to the defaults built into the chart. To preserve the previously set values, you must use the `--reuse-values` flag.
 Alternatively, provide the full set of values, including any overrides applied during installation.
 * It is recommended to upgrade 1 minor release at a time, otherwise you may run into unexpected issues.
 * It is recommended to upgrade to the latest patch release first before upgrading to the next minor release.

--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -114,6 +114,9 @@ helm upgrade everest percona/everest-db-namespace --namespace [DB NAMESPACE] --v
 ```
 
 Notes:
+* :warning: When specifying values during an upgrade (i.e, using `--set`, `--set-json`, `--values`, etc.), Helm resets all the other values
+to the defaults built into the chart. To preserve the previously set values, you must use the `--reuse-flag`.
+Alternatively, provide the full set of values, including any overrides applied during installation.
 * It is recommended to upgrade 1 minor release at a time, otherwise you may run into unexpected issues.
 * It is recommended to upgrade to the latest patch release first before upgrading to the next minor release.
 * To ensure that the upgrade happens safely, we run a pre-upgrade hook that runs a series of checks. This can be disabled by setting `upgrade.preflightChecks=false`.

--- a/charts/everest/README.md.gotmpl
+++ b/charts/everest/README.md.gotmpl
@@ -114,6 +114,9 @@ helm upgrade everest percona/everest-db-namespace --namespace [DB NAMESPACE] --v
 ```
 
 Notes:
+* :warning: When specifying values during an upgrade (i.e, using `--set`, `--set-json`, `--values`, etc.), Helm resets all the other values
+to the defaults built into the chart. To preserve the previously set values, you must use the `--reuse-flag`. 
+Alternatively, provide the full set of values, including any overrides applied during installation.
 * It is recommended to upgrade 1 minor release at a time, otherwise you may run into unexpected issues.
 * It is recommended to upgrade to the latest patch release first before upgrading to the next minor release.
 * To ensure that the upgrade happens safely, we run a pre-upgrade hook that runs a series of checks. This can be disabled by setting `upgrade.preflightChecks=false`.

--- a/charts/everest/README.md.gotmpl
+++ b/charts/everest/README.md.gotmpl
@@ -115,7 +115,7 @@ helm upgrade everest percona/everest-db-namespace --namespace [DB NAMESPACE] --v
 
 Notes:
 * :warning: When specifying values during an upgrade (i.e, using `--set`, `--set-json`, `--values`, etc.), Helm resets all the other values
-to the defaults built into the chart. To preserve the previously set values, you must use the `--reuse-flag`. 
+to the defaults built into the chart. To preserve the previously set values, you must use the `--reuse-values` flag. 
 Alternatively, provide the full set of values, including any overrides applied during installation.
 * It is recommended to upgrade 1 minor release at a time, otherwise you may run into unexpected issues.
 * It is recommended to upgrade to the latest patch release first before upgrading to the next minor release.


### PR DESCRIPTION
Specifying `--set` (or other equivalent flags) with `helm upgrade ..` causes Helm to reset all the other values to the ones built into the chart. To prevent this, user should specify `--reuse-values` or specify the whole set of values including the ones used for install.