### PR TITLE
Remove Extra creationTimestamp:null in OLM CRD

### DIFF
--- a/charts/everest/crds/olm.yaml
+++ b/charts/everest/crds/olm.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: catalogsources.operators.coreos.com
 spec:
   group: operators.coreos.com
@@ -260,7 +259,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: clusterserviceversions.operators.coreos.com
 spec:
   group: operators.coreos.com
@@ -5559,7 +5557,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: installplans.operators.coreos.com
 spec:
   group: operators.coreos.com
@@ -5825,7 +5822,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: olmconfigs.operators.coreos.com
 spec:
   group: operators.coreos.com
@@ -5923,7 +5919,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: operatorconditions.operators.coreos.com
 spec:
   group: operators.coreos.com
@@ -6230,7 +6225,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: operatorgroups.operators.coreos.com
 spec:
   group: operators.coreos.com
@@ -6517,7 +6511,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: operators.operators.coreos.com
 spec:
   group: operators.coreos.com
@@ -6656,7 +6649,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
   name: subscriptions.operators.coreos.com
 spec:
   group: operators.coreos.com


### PR DESCRIPTION
Hey team,

Hope you are doing alright. Thought it might be useful to remove `creationTimestamp: null` in Everest's CRD, **olm.yaml**. Please ket me know if this is used for a specific reason.

Great job! 