### PR TITLE
EVEREST-1852 | Add the ability to deploy PMM with Everest

### DIFF
--- a/charts/everest/Chart.lock
+++ b/charts/everest/Chart.lock
@@ -11,5 +11,8 @@ dependencies:
 - name: victoria-metrics-operator
   repository: https://victoriametrics.github.io/helm-charts
   version: 0.37.0
-digest: sha256:b219948462cc632aa1b2b1bd80e7831c9cbfd9aa22d38a1eaa6e61c70bfe563c
-generated: "2024-12-18T15:46:21.983602+05:30"
+- name: pmm
+  repository: https://percona.github.io/percona-helm-charts
+  version: 1.3.21
+digest: sha256:885646b6a34c93926c85ed281d348d76809bb3fb0da85414c064244120ba85cb
+generated: "2025-01-29T16:38:08.280493+05:30"

--- a/charts/everest/Chart.yaml
+++ b/charts/everest/Chart.yaml
@@ -33,3 +33,7 @@ dependencies:
     version: 0.37.0
     repository: "https://victoriametrics.github.io/helm-charts"
     condition: "monitoring.enabled"
+  - name: pmm
+    repository: "https://percona.github.io/percona-helm-charts"
+    condition: "pmm.enabled"
+    version: 1.3.*

--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -161,6 +161,8 @@ The following table shows the configurable parameters of the Percona Everest cha
 | operator.image | string | `"perconalab/everest-operator"` | Image to use for the Everest operator container. |
 | operator.metricsAddr | string | `"127.0.0.1:8080"` | Metrics address for the operator. |
 | operator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"5m","memory":"64Mi"}}` | Resources to allocate for the operator container. |
+| pmm | object | `{"enabled":false,"nameOverride":"pmm"}` | PMM settings. |
+| pmm.enabled | bool | `false` | If set, deploys PMM in the release namespace. |
 | server.apiRequestsRateLimit | int | `100` | Set the allowed number of requests per second. |
 | server.env | list | `[]` | Additional environment variables to pass to the server deployment. |
 | server.image | string | `"perconalab/everest"` | Image to use for the server container. |

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -147,3 +147,9 @@ monitoring:
     enabled: false
   certManager:
     enabled: false
+
+# -- PMM settings.
+pmm:
+  # -- If set, deploys PMM in the release namespace.
+  enabled: false
+  nameOverride: pmm


### PR DESCRIPTION
- Setting `pmm.enabled=true` will deploy the PMM helm chart as well.
- PMM chart overrides may be specified in the `pmm` field
- Currently PMM is deployed in the release namespace, i.e `everest-system`. PMM chart does not have a way to provide a `namespaceOverride` (can be a future improvement)