### PR TITLE
pg-db - Added missing PerconaPGCluster .spec.standby. fields

### DIFF
--- a/charts/pg-db/Chart.yaml
+++ b/charts/pg-db/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pg-db
 description: 'A Helm chart to deploy the PostgreSQL database with the Percona Operator for PostgreSQL'
 type: application
-version: 2.5.1
+version: 2.5.2
 appVersion: 2.5.0
 home: https://docs.percona.com/percona-operator-for-postgresql/2.0/
 maintainers:

--- a/charts/pg-db/templates/cluster.yaml
+++ b/charts/pg-db/templates/cluster.yaml
@@ -21,8 +21,7 @@ spec:
   imagePullPolicy: Always
   port: {{ default 5432 .Values.port }}
   postgresVersion: {{ .Values.postgresVersion }}
-  standby:
-    enabled: {{ .Values.standby.enabled }}
+  standby: {{- .Values.standby | toYaml | nindent 4 }}
   {{- if or (.Values.customTLSSecret.name) (.Values.customReplicationTLSSecret.name) }}
   secrets:
     {{- if .Values.customRootCATLSSecret.name }}


### PR DESCRIPTION
This PR should fix the missing fields in .spec.standby by passing them all-through leaving the validation up to the operator