### PR TITLE
EVEREST-1625 align helm and operator crds

### DIFF
--- a/charts/everest/crds/everest.yaml
+++ b/charts/everest/crds/everest.yaml
@@ -476,8 +476,6 @@ spec:
                       - schedule
                       type: object
                     type: array
-                required:
-                - enabled
                 type: object
               dataSource:
                 description: DataSource defines a data source for bootstraping a new


### PR DESCRIPTION
In the scope of EVEREST-1625 the `.backup.enabled` field got optional, but this change was missing in the helm manifests. 

Note: CI is going to be fixed once the operator PR https://github.com/percona/everest-operator/pull/714 is merged