### PR TITLE
Fix broken values chart in PXC-DB README

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.17.0
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.17.0
+version: 1.17.1
 maintainers:
   - name: eleo007
     email: eleonora.zinchenko@percona.com

--- a/charts/pxc-db/README.md
+++ b/charts/pxc-db/README.md
@@ -261,15 +261,12 @@ The chart can be customized using the following configurable parameters:
 | `pmm.livenessProbes.periodSeconds`       | How often (in seconds) to perform the probe                                                                                                                                                         | `10`                                |
 | `pmm.livenessProbes.successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed                                                                                                         | `1`                                 |
 | `pmm.livenessProbes.timeoutSeconds`      | Number of seconds after which the probe times out                                                                                                                                                   | `5`                                 |
-
 | `users.name`                   | The username of the PXC application user                                                                                                                                                                        | `""` |
 | `users.dbs`                    | Database that will be applied to the user                                                                                                                                                                       | `[]` |
 | `users.grants`                 | Grants that will be applied to the user                                                                                                                                                                         | `[]` |
 | `users.withGrantOption`        | Set grant options for the user                                                                                                                                                                                  | `[]` |
 | `users.passwordSecretRef.name` | Name of the secret that contains the user's password                                                                                                                                                            | `""` |
 | `users.passwordSecretRef.key`  | Key in the secret that corresponds to the value of the user's password                                                                                                                                          | `""` |
-
-
 | |
 | `backup.enabled`                                                                 | Enables backups for PXC cluster                                                                                                                               | `true`                                    |
 | `backup.allowParallel`                                                           | Allow taking multiple backups in parallel                                                                                                                     | `true`                                    |


### PR DESCRIPTION
The extra line breaks were causing rendering errors in the markdown