### PR TITLE
EVEREST-343 use percona/olm fork image

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -162,7 +162,7 @@ The following table shows the configurable parameters of the Percona Everest cha
 | ingress.tls | list | `[]` | Each entry in the list specifies a TLS certificate and the hosts it applies to. |
 | namespaceOverride | string | `""` | Namespace override. Defaults to the value of .Release.Namespace. |
 | olm.catalogSourceImage | string | `"perconalab/everest-catalog"` | Image to use for Everest CatalogSource. |
-| olm.image | string | `"quay.io/operator-framework/olm@sha256:1b6002156f568d722c29138575733591037c24b4bfabc67946f268ce4752c3e6"` | Image to use for the OLM components. |
+| olm.image | string | `"percona/olm@sha256:13e8f4e919e753faa7da35a9064822381098bcd44acc284877bf0964ceecbfd5"` | Image to use for the OLM components. |
 | olm.install | bool | `true` | If set, installs OLM in the provided namespace. |
 | olm.namespace | string | `"everest-olm"` | Namespace where OLM is installed. Do no change unless you know what you are doing. |
 | olm.packageserver.tls.caCert | string | `""` | CA certificate for the PackageServer APIService. Overrides the tls.type setting. |

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -166,7 +166,7 @@ olm:
   # -- Image to use for Everest CatalogSource.
   catalogSourceImage: perconalab/everest-catalog
   # -- Image to use for the OLM components.
-  image: quay.io/operator-framework/olm@sha256:1b6002156f568d722c29138575733591037c24b4bfabc67946f268ce4752c3e6
+  image: percona/olm@sha256:13e8f4e919e753faa7da35a9064822381098bcd44acc284877bf0964ceecbfd5
   packageserver:
     tls:
       # -- Type of TLS certificates. Supported values are "helm" and "cert-manager".


### PR DESCRIPTION
We forked OLM to fix the bug that was blocking installation on GKE autopilot clusters.
See the PR for more info:
https://github.com/percona/operator-lifecycle-manager/pull/1