### PR TITLE
K8SPS-456: Allow setting custom environment variables

### DIFF
--- a/charts/ps-db/Chart.yaml
+++ b/charts/ps-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "0.12.0"
 description: A Helm chart for installing Percona Server Databases using the PS Operator.
 name: ps-db
 home: https://www.percona.com/doc/kubernetes-operator-for-mysql/ps
-version: 0.12.0
+version: 0.12.1
 maintainers:
   - name: jvpasinatto
     email: julio.pasinatto@percona.com

--- a/charts/ps-db/README.md
+++ b/charts/ps-db/README.md
@@ -19,7 +19,7 @@ To install the chart with the `ps` release name using a dedicated namespace (rec
 
 ```sh
 helm repo add percona https://percona.github.io/percona-helm-charts/
-helm install my-db percona/ps-db --version 0.12.0 --namespace my-namespace
+helm install my-db percona/ps-db --version 0.12.1 --namespace my-namespace
 ```
 
 The chart can be customized using the following configurable parameters:
@@ -94,6 +94,7 @@ The chart can be customized using the following configurable parameters:
 | `mysql.exposePrimary.internalTrafficPolicy`       | Network service internalTrafficPolicy                                                                                                                         | ``                         |
 | `mysql.exposePrimary.labels`                      | Network service labels                                                                                                                                        | `{}`                       |
 | `mysql.exposePrimary.loadBalancerSourceRanges`    | The range of client IP addresses from which the load balancer should be reachable                                                                             | `[]`                       |
+| `mysql.env`                                       | Additional environment variables to pass to the cluster.                             | `[]`                          |
 | `mysql.volumeSpec`                                | MySQL Pods storage resources                                                                                                                                  | `{}`                       |
 | `mysql.volumeSpec.pvc`                            | MySQL Pods PVC request parameters                                                                                                                             |                            |
 | `mysql.volumeSpec.pvc.storageClassName`           | MySQL Pods PVC target storageClass                                                                                                                            | `""`                       |

--- a/charts/ps-db/templates/cluster.yaml
+++ b/charts/ps-db/templates/cluster.yaml
@@ -205,6 +205,10 @@ spec:
     configuration: |
 {{- tpl $mysql.configuration $ | nindent 6 }}
     {{- end }}
+    {{- if $mysql.env }}
+    env:
+{{ $mysql.env | toYaml | indent 6 }}
+    {{- end }}
     {{- if $mysql.sidecars }}
     sidecars:
 {{ $mysql.sidecars | toYaml | indent 6 }}


### PR DESCRIPTION
This commit adds support for defining `.Values.mysql.env` which will be propagated to the PerconaServerMySQL and as a result to the MySQL statefulset. That could be useful especially since Percona MySQL operator added support for BOOTSTRAP_READ_TIMEOUT.