### PR TITLE
K8SPG-723 Add CRD warning for Helm upgrade

### DIFF
--- a/charts/pg-operator/templates/NOTES.txt
+++ b/charts/pg-operator/templates/NOTES.txt
@@ -18,7 +18,8 @@
   {{- range $name := $crdNames }}
     {{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $name }}
     {{- if $crd }}
-      {{- $crdVersion := index $crd.metadata.labels "pgv2.percona.com/version" }}
+      {{- $crdLabels := (($crd).metadata).labels | default dict }}
+      {{- $crdVersion := index $crdLabels "pgv2.percona.com/version" }}
       {{- if or (not $crdVersion) (semverCompare (printf "< %s" $.Chart.AppVersion) (trimPrefix "v" $crdVersion)) }}
         {{- $_ := set $ctx "upgradeCrd" true }}
       {{- end }}

--- a/charts/pg-operator/templates/NOTES.txt
+++ b/charts/pg-operator/templates/NOTES.txt
@@ -18,7 +18,7 @@
 
 Please manually apply any new CRDs:
 
-        kubectl apply -f --server-side crds/
+  kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/percona/percona-postgresql-operator/v{{ .Chart.AppVersion }}/deploy/crd.yaml
 {{- end }}
 
 Read more in our documentation: https://docs.percona.com/percona-operator-for-postgresql/2.0/

--- a/charts/pg-operator/templates/NOTES.txt
+++ b/charts/pg-operator/templates/NOTES.txt
@@ -12,4 +12,13 @@
 
     helm install my-db percona/pg-db --namespace={{ .Release.Namespace }}
 
+{{- if .Release.IsUpgrade }}
+
+** WARNING ** During Helm upgrade CRDs are not automatically upgraded.
+
+Please manually apply any new CRDs:
+
+        kubectl apply -f --server-side crds/
+{{- end }}
+
 Read more in our documentation: https://docs.percona.com/percona-operator-for-postgresql/2.0/

--- a/charts/pg-operator/templates/NOTES.txt
+++ b/charts/pg-operator/templates/NOTES.txt
@@ -13,12 +13,25 @@
     helm install my-db percona/pg-db --namespace={{ .Release.Namespace }}
 
 {{- if .Release.IsUpgrade }}
+  {{- $ctx := dict "upgradeCrd" false }}
+  {{- $crdNames := list "perconapgclusters.pgv2.percona.com" "perconapgbackups.pgv2.percona.com" "perconapgrestores.pgv2.percona.com" }}
+  {{- range $name := $crdNames }}
+    {{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $name }}
+    {{- if $crd }}
+      {{- $crdVersion := index $crd.metadata.labels "pgv2.percona.com/version" }}
+      {{- if or (not $crdVersion) (semverCompare (printf "< %s" $.Chart.AppVersion) (trimPrefix "v" $crdVersion)) }}
+        {{- $_ := set $ctx "upgradeCrd" true }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- if $ctx.upgradeCrd }}
 
 ** WARNING ** During Helm upgrade CRDs are not automatically upgraded.
 
 Please manually apply any new CRDs:
 
   kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/percona/percona-postgresql-operator/v{{ .Chart.AppVersion }}/deploy/crd.yaml
+  {{- end }}
 {{- end }}
 
 Read more in our documentation: https://docs.percona.com/percona-operator-for-postgresql/2.0/


### PR DESCRIPTION
According to the [Helm documentation on custom resource definitions](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/), starting with Helm 3, the crds/ directory is used to automatically install CRDs required for Operator deployments.

During installation, a CRD from the crds/ directory is only applied if it does not already exist in the cluster. If it exists, Helm will skip it and print a warning. However, during upgrades, Helm always skips applying CRDs, without attempting to check or update them.

To provide better guidance to users during Helm upgrades, a warning can now be displayed based on the CRD version, extracted from the pgv2.percona.com/version label. This helps inform users when a newer version of the CRDs is available without automatically applying them.
Examples:

- Upgrade from 2.7.0 to 2.8.0: If the CRDs in the cluster are still at version 2.7.0, a warning will be printed at the end of the upgrade, suggesting a manual CRD update.

- Upgrade from 2.5.0 to 2.7.0: If the CRD in the cluster does not have the version label (e.g., it's missing or from an older version), the warning will also be shown to suggest updating the CRD.

- Upgrade from 2.4.0 to 2.5.0: No warning will be displayed, since this version does not yet include the CRD version check (introduced in 2.7.0).

- Upgrade from 2.6.0 to 2.7.0: If the CRD is already at version 2.7.0 in the cluster, no warning will be shown.