### PR TITLE
K8SPXC-1569 add version label to crd.yaml

### DIFF
--- a/charts/pxc-operator/crds/crd.yaml
+++ b/charts/pxc-operator/crds/crd.yaml
@@ -3,6 +3,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
+  labels:
+    percona.com/version: v1.18.0
   name: perconaxtradbclusterbackups.pxc.percona.com
 spec:
   group: pxc.percona.com
@@ -260,6 +262,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
+  labels:
+    percona.com/version: v1.18.0
   name: perconaxtradbclusterrestores.pxc.percona.com
 spec:
   group: pxc.percona.com
@@ -666,6 +670,8 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
+  labels:
+    percona.com/version: v1.18.0
   name: perconaxtradbclusters.pxc.percona.com
 spec:
   group: pxc.percona.com

--- a/charts/pxc-operator/crds/crd.yaml
+++ b/charts/pxc-operator/crds/crd.yaml
@@ -4,7 +4,10 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
-    percona.com/version: v1.18.0
+    app.kubernetes.io/component: crd
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster-operator
+    app.kubernetes.io/version: v1.18.0
   name: perconaxtradbclusterbackups.pxc.percona.com
 spec:
   group: pxc.percona.com
@@ -263,7 +266,10 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
-    percona.com/version: v1.18.0
+    app.kubernetes.io/component: crd
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster-operator
+    app.kubernetes.io/version: v1.18.0
   name: perconaxtradbclusterrestores.pxc.percona.com
 spec:
   group: pxc.percona.com
@@ -671,7 +677,10 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.3
   labels:
-    percona.com/version: v1.18.0
+    app.kubernetes.io/component: crd
+    app.kubernetes.io/name: percona-xtradb-cluster
+    app.kubernetes.io/part-of: percona-xtradb-cluster-operator
+    app.kubernetes.io/version: v1.18.0
   name: perconaxtradbclusters.pxc.percona.com
 spec:
   group: pxc.percona.com


### PR DESCRIPTION
This change the following labels used to crarify relation between  CRD and Operator version:
```
   app.kubernetes.io/component: crd
   app.kubernetes.io/name: percona-xtradb-cluster
   app.kubernetes.io/part-of: percona-xtradb-cluster-operator
   app.kubernetes.io/version: v<version>
```