### PR TITLE
EVEREST-2279 | Allow preserving webhook server TLS certificates during helm upgrades

### DIFF
--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -197,6 +197,7 @@ The following table shows the configurable parameters of the Percona Everest cha
 | operator.metricsAddr | string | `"127.0.0.1:8080"` | Metrics address for the operator. |
 | operator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"5m","memory":"64Mi"}}` | Resources to allocate for the operator container. |
 | operator.webhook.certs | object | `{"ca.crt":"","tls.crt":"","tls.key":""}` | Certificates to use for the webhook server. The values must be base64 encoded. If unset, uses self-signed certificates. |
+| operator.webhook.preserveTLSCerts | bool |  | If set to true, preserves the existing TLS Certificate Secrets. Ignored if certificates are explicitly provided in operator.webhook.certs, in which case, the specifed certificater are used. Ignored during installation. |
 | pmm | object | `{"enabled":false,"nameOverride":"pmm"}` | PMM settings. |
 | pmm.enabled | bool | `false` | If set, deploys PMM in the release namespace. |
 | server.apiRequestsRateLimit | int | `100` | Set the allowed number of requests per second. |

--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -197,7 +197,7 @@ The following table shows the configurable parameters of the Percona Everest cha
 | operator.metricsAddr | string | `"127.0.0.1:8080"` | Metrics address for the operator. |
 | operator.resources | object | `{"limits":{"cpu":"500m","memory":"128Mi"},"requests":{"cpu":"5m","memory":"64Mi"}}` | Resources to allocate for the operator container. |
 | operator.webhook.certs | object | `{"ca.crt":"","tls.crt":"","tls.key":""}` | Certificates to use for the webhook server. The values must be base64 encoded. If unset, uses self-signed certificates. |
-| operator.webhook.preserveTLSCerts | bool |  | If set to true, preserves the existing TLS Certificate Secrets. Ignored if certificates are explicitly provided in operator.webhook.certs, in which case, the specifed certificater are used. Ignored during installation. |
+| operator.webhook.preserveTLSCerts | bool |  | If set to true, preserves existing TLS Certificate Secrets during upgrades. This setting is ignored if certificates are explicitly provided in operator.webhook.certs, in which case the specified certificates are used instead. This setting has no effect during installation. |
 | pmm | object | `{"enabled":false,"nameOverride":"pmm"}` | PMM settings. |
 | pmm.enabled | bool | `false` | If set, deploys PMM in the release namespace. |
 | server.apiRequestsRateLimit | int | `100` | Set the allowed number of requests per second. |

--- a/charts/everest/templates/_helpers.tpl
+++ b/charts/everest/templates/_helpers.tpl
@@ -104,11 +104,19 @@ tls.crt: {{ index $tlsCerts "tls.crt" | default $cert.Cert | b64enc }}
 {{- end }}
 
 {{- define "everestOperator.tlsCerts" -}}
+{{- $currentSecret := lookup "v1" "Secret" (include "everest.namespace" .) "webhook-server-cert" -}}
 {{- $tlsCerts := .Values.operator.webhook.certs }}
+
 {{- if (and (get $tlsCerts "tls.key" ) (get $tlsCerts "tls.crt") (get $tlsCerts "ca.crt") )}}
 tls.key: {{ index $tlsCerts "tls.key" }}
 tls.crt: {{ index $tlsCerts "tls.crt" }}
 ca.crt: {{ index $tlsCerts "ca.crt" }}
+
+{{- else if (and .Release.IsUpgrade .Values.operator.webhook.preserveTLSCerts $currentSecret ) }}
+tls.key: {{ index $currentSecret.data "tls.key" }}
+tls.crt: {{ index $currentSecret.data "tls.crt" }}
+ca.crt: {{ index $currentSecret.data "ca.crt" }}
+
 {{- else }}
 {{- $svcName := printf "everest-operator-webhook-service" }}
 {{- $svcNameWithNS := ( printf "%s.%s" $svcName (include "everest.namespace" .) ) }}

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -159,6 +159,13 @@ operator:
       tls.crt: ""
       ca.crt: ""
 
+    # -- If set to true, preserves the existing TLS Certificate Secrets.
+    # Ignored if certificates are explicitly provided in operator.webhook.certs,
+    # in which case, the specifed certificater are used.
+    # Ignored during installation.
+    # @default -- true
+    preserveTLSCerts: true
+
 dataImporters:
   # -- Settings for the Percona PostgreSQL Operator data importer.
   perconaPGOperator:

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -159,10 +159,10 @@ operator:
       tls.crt: ""
       ca.crt: ""
 
-    # -- If set to true, preserves the existing TLS Certificate Secrets.
-    # Ignored if certificates are explicitly provided in operator.webhook.certs,
-    # in which case, the specifed certificater are used.
-    # Ignored during installation.
+    # -- If set to true, preserves existing TLS Certificate Secrets during upgrades.
+    # This setting is ignored if certificates are explicitly provided in operator.webhook.certs,
+    # in which case the specified certificates are used instead.
+    # This setting has no effect during installation.
     # @default -- true
     preserveTLSCerts: true
 


### PR DESCRIPTION
### Problem

Running `helm upgrade` can cause the `webhook-server-cert` Secret content to change. This can have some unintended consequences.

### Solution

- introduce a new `preserveTLSCerts` value (default is `true`) that will allow you to preserve TLS Secret during helm upgrade
- this field is ignored during installation, or if Secrets are explicitly specified