### PR TITLE
EVEREST-2303 | Move from bitnami/kubectl image

### DIFF
--- a/charts/everest/Chart.lock
+++ b/charts/everest/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: file://charts/common
-  version: 0.0.18
+  version: 0.0.19
 - name: everest-db-namespace
   repository: file://charts/everest-db-namespace
   version: 0.0.0
@@ -20,5 +20,5 @@ dependencies:
 - name: operator-lifecycle-manager
   repository: https://percona.github.io/operator-lifecycle-manager
   version: 0.1.0
-digest: sha256:173cc5fe0aa501e3a21e6c492f167d12f7d06c1c81dfa23b03944a1104a02fd1
-generated: "2025-06-19T12:46:45.206626+05:30"
+digest: sha256:4d289295eb9b0fee8fd9add3a2ec3b19dd5e9a61479fbd424ddd3e4cd519a8d3
+generated: "2025-09-15T18:35:57.327248+05:30"

--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -176,7 +176,7 @@ The following table shows the configurable parameters of the Percona Everest cha
 | dbNamespace.enabled | bool | `true` | If set, deploy the database operators in `everest` namespace. The namespace may be overridden by setting `dbNamespace.namespaceOverride`. |
 | dbNamespace.namespaceOverride | string | `"everest"` | If `dbNamespace.enabled` is `true`, deploy the database operators in this namespace. |
 | hooks | object | `{"image":"bitnamilegacy/kubectl","pspCleanup":{},"upgradeChecks":{"image":"alpine:3.20"}}` | Configuration for Helm chart hooks. |
-| hooks.image | string | `"bitnamilegacy/kubectl"` | Default image to use for the Helm chart hooks job. |
+| hooks.image | string |  | Default image to use for the Helm chart hooks job. |
 | hooks.upgradeChecks | object | `{"image":"alpine:3.20"}` | Image to use for the PSP cleanup job. If not set, uses the value of `hooks.image`. image: "" |
 | hooks.upgradeChecks.image | string |  | Image to use for the upgrade checks job. If not set, uses the value of `hooks.image`. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress resource. |

--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -175,6 +175,10 @@ The following table shows the configurable parameters of the Percona Everest cha
 | dataImporters.perconaPXCOperator.enabled | bool | `true` | If set, installs the Percona PXC Operator data importer. |
 | dbNamespace.enabled | bool | `true` | If set, deploy the database operators in `everest` namespace. The namespace may be overridden by setting `dbNamespace.namespaceOverride`. |
 | dbNamespace.namespaceOverride | string | `"everest"` | If `dbNamespace.enabled` is `true`, deploy the database operators in this namespace. |
+| hooks | object | `{"image":"bitnamilegacy/kubectl","pspCleanup":{},"upgradeChecks":{"image":"alpine:3.20"}}` | Configuration for Helm chart hooks. |
+| hooks.image | string |  | Default image to use for the Helm chart hooks job. |
+| hooks.upgradeChecks | object | `{"image":"alpine:3.20"}` | Image to use for the PSP cleanup job. If not set, uses the value of `hooks.image`. image: "" |
+| hooks.upgradeChecks.image | string |  | Image to use for the upgrade checks job. If not set, uses the value of `hooks.image`. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress resource. |
 | ingress.enabled | bool | `false` | Enable ingress for Everest server |
 | ingress.hosts | list | `[{"host":"chart-example.local","paths":[{"path":"/","pathType":"ImplementationSpecific"}]}]` | List of hosts and their paths for the ingress resource. |

--- a/charts/everest/README.md
+++ b/charts/everest/README.md
@@ -176,7 +176,7 @@ The following table shows the configurable parameters of the Percona Everest cha
 | dbNamespace.enabled | bool | `true` | If set, deploy the database operators in `everest` namespace. The namespace may be overridden by setting `dbNamespace.namespaceOverride`. |
 | dbNamespace.namespaceOverride | string | `"everest"` | If `dbNamespace.enabled` is `true`, deploy the database operators in this namespace. |
 | hooks | object | `{"image":"bitnamilegacy/kubectl","pspCleanup":{},"upgradeChecks":{"image":"alpine:3.20"}}` | Configuration for Helm chart hooks. |
-| hooks.image | string |  | Default image to use for the Helm chart hooks job. |
+| hooks.image | string | `"bitnamilegacy/kubectl"` | Default image to use for the Helm chart hooks job. |
 | hooks.upgradeChecks | object | `{"image":"alpine:3.20"}` | Image to use for the PSP cleanup job. If not set, uses the value of `hooks.image`. image: "" |
 | hooks.upgradeChecks.image | string |  | Image to use for the upgrade checks job. If not set, uses the value of `hooks.image`. |
 | ingress.annotations | object | `{}` | Additional annotations for the ingress resource. |

--- a/charts/everest/charts/common/Chart.yaml
+++ b/charts/everest/charts/common/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: common
 description: A library chart for Everest containing common resources.
 type: library
-version: 0.0.18
+version: 0.0.19
 appVersion: "0.0.3"
 maintainers:
   - name: mayankshah1607

--- a/charts/everest/charts/common/README.md
+++ b/charts/everest/charts/common/README.md
@@ -1,6 +1,6 @@
 # common
 
-![Version: 0.0.18](https://img.shields.io/badge/Version-0.0.18-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
+![Version: 0.0.19](https://img.shields.io/badge/Version-0.0.19-informational?style=flat-square) ![Type: library](https://img.shields.io/badge/Type-library-informational?style=flat-square) ![AppVersion: 0.0.3](https://img.shields.io/badge/AppVersion-0.0.3-informational?style=flat-square)
 
 A library chart for Everest containing common resources.
 

--- a/charts/everest/charts/common/templates/_csv_cleanup.yaml.tpl
+++ b/charts/everest/charts/common/templates/_csv_cleanup.yaml.tpl
@@ -1,5 +1,6 @@
 #
 # @param .namespace     The namespace where the operator is installed
+# @param .image         The image to use for running the hook Job
 #
 {{- define "everest.csvCleanup" }}
 {{- $hookName := printf "everest-helm-pre-delete-hook" }}
@@ -59,7 +60,7 @@ spec:
   template:
     spec:
       containers:
-        - image: bitnami/kubectl:latest
+        - image: {{ .image }}
           name: {{ $hookName }}
           command:
             - /bin/sh

--- a/charts/everest/charts/common/templates/_db_resources_cleanup.yaml.tpl
+++ b/charts/everest/charts/common/templates/_db_resources_cleanup.yaml.tpl
@@ -1,5 +1,6 @@
 #
 # @param .namespace     The namespace where DB and its resources are deployed
+# @param .image         The image to use for running the hook Job
 #
 {{- define "everest.dbResourcesCleanup" }}
 {{- $hookName := printf "everest-helm-pre-delete-db-resource-cleanup" }}
@@ -66,7 +67,7 @@ spec:
   template:
     spec:
       containers:
-        - image: bitnami/kubectl:latest
+        - image: {{ .image }}
           name: {{ $hookName }}
           command:
             - /bin/sh

--- a/charts/everest/charts/common/templates/_operators_installer.yaml.tpl
+++ b/charts/everest/charts/common/templates/_operators_installer.yaml.tpl
@@ -1,5 +1,6 @@
 #
 # @param .namespace     The namespace where the operators are installed
+# @param .image         The image to use for running the hook Job
 #
 {{- define "everest.operatorsInstaller" }}
 {{- $hookName := "everest-operators-installer" }}
@@ -79,7 +80,7 @@ spec:
   template:
     spec:
       containers:
-        - image: bitnami/kubectl:latest
+        - image: {{ .image }}
           name: {{ $hookName }}
           command:
             - /bin/sh

--- a/charts/everest/charts/common/templates/_psp_cleanup.yaml.tpl
+++ b/charts/everest/charts/common/templates/_psp_cleanup.yaml.tpl
@@ -1,6 +1,7 @@
 # Cleanup all default pod scheduling policies during uninstall.
 #
 # @param .namespace     The namespace where Everest server is installed
+# @param .image         The image to use for running the hook Job
 #
 {{- define "everest.pspCleanup" }}
 {{- $hookName := printf "everest-helm-psp-cleanup-hook" }}
@@ -63,7 +64,7 @@ spec:
   template:
     spec:
       containers:
-        - image: bitnami/kubectl:latest
+        - image: {{ .image }}
           name: {{ $hookName }}
           command:
             - /bin/sh

--- a/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
+++ b/charts/everest/charts/common/templates/_upgrade_checks.yaml.tpl
@@ -2,6 +2,7 @@
 # @param .namespace             The namespace where the operator is installed
 # @param .version               Version to upgrade to
 # @param .versionMetadataURL    The URL of the version metadata service
+# @param .image                 The image to use for running the hook Job
 #
 {{- define "everest.preUpgradeChecks" }}
 {{- $hookName := printf "everest-helm-pre-upgrade-hook" }}
@@ -98,7 +99,7 @@ spec:
   template:
     spec:
       containers:
-        - image: alpine:3.20
+        - image: {{ .image }}
           name: {{ $hookName }}
           command:
             - /bin/sh

--- a/charts/everest/charts/everest-db-namespace/Chart.lock
+++ b/charts/everest/charts/everest-db-namespace/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: file://../common
-  version: 0.0.18
-digest: sha256:b5530e17ed3093be96dc7a77a5760e824b261f7f73f704383599175ebfa2d08d
-generated: "2025-06-18T21:14:00.324683+05:30"
+  version: 0.0.19
+digest: sha256:c8aa58f0af7f7c7eb34e962c9f7afe6ec3a7bc4490c69b1c16aef8674e390112
+generated: "2025-09-15T18:36:03.132053+05:30"

--- a/charts/everest/charts/everest-db-namespace/README.md
+++ b/charts/everest/charts/everest-db-namespace/README.md
@@ -27,6 +27,11 @@ Kubernetes: `>= 1.27.0-0`
 |-----|------|---------|-------------|
 | cleanupOnUninstall | bool | `true` | If set, cleans up the DB resources on uninstall. |
 | compatibility.openshift | bool | `false` | If set, enable OpenShift compatibility. |
+| hooks | object | `{"csvCleanup":{},"dbResourcesCleanup":{},"image":"bitnamilegacy/kubectl","operatorsInstaller":{}}` | Configuration for Helm chart hooks. |
+| hooks.csvCleanup | object | `{}` | Configuration for the CSV cleanup job. |
+| hooks.dbResourcesCleanup | object | `{}` | Configuration for the DB resources cleanup job. |
+| hooks.image | string | `registry.k8s.io/kubectl` | Default image to use for the Helm chart hooks job. |
+| hooks.operatorsInstaller | object | `{}` | Configuration for the operators installer job. |
 | namespaceOverride | string | `""` | Namespace override. Defaults to the value of .Release.Namespace. |
 | postgresql | bool | `true` | If set, installs the Percona Postgresql Server operator. |
 | psmdb | bool | `true` | If set, installs the Percona Server MongoDB operator. |

--- a/charts/everest/charts/everest-db-namespace/README.md
+++ b/charts/everest/charts/everest-db-namespace/README.md
@@ -30,7 +30,7 @@ Kubernetes: `>= 1.27.0-0`
 | hooks | object | `{"csvCleanup":{},"dbResourcesCleanup":{},"image":"bitnamilegacy/kubectl","operatorsInstaller":{}}` | Configuration for Helm chart hooks. |
 | hooks.csvCleanup | object | `{}` | Configuration for the CSV cleanup job. |
 | hooks.dbResourcesCleanup | object | `{}` | Configuration for the DB resources cleanup job. |
-| hooks.image | string | `registry.k8s.io/kubectl` | Default image to use for the Helm chart hooks job. |
+| hooks.image | string | `bitnamilegacy/kubectl` | Default image to use for the Helm chart hooks job. |
 | hooks.operatorsInstaller | object | `{}` | Configuration for the operators installer job. |
 | namespaceOverride | string | `""` | Namespace override. Defaults to the value of .Release.Namespace. |
 | postgresql | bool | `true` | If set, installs the Percona Postgresql Server operator. |

--- a/charts/everest/charts/everest-db-namespace/templates/hooks.yaml
+++ b/charts/everest/charts/everest-db-namespace/templates/hooks.yaml
@@ -1,7 +1,7 @@
-{{- include "everest.csvCleanup" (dict "namespace" (include "db.namespace" .)) }}
+{{- include "everest.csvCleanup" (dict "namespace" (include "db.namespace" .) "image" (.Values.hooks.csvCleanup.image | default .Values.hooks.image)) }}
 ---
-{{- include "everest.operatorsInstaller" (dict "namespace" (include "db.namespace" .)) }}
+{{- include "everest.operatorsInstaller" (dict "namespace" (include "db.namespace" .) "image" (.Values.hooks.operatorsInstaller.image | default .Values.hooks.image)) }}
 ---
 {{ if .Values.cleanupOnUninstall }}
-{{- include "everest.dbResourcesCleanup" (dict "namespace" (include "db.namespace" .)) }}
+{{- include "everest.dbResourcesCleanup" (dict "namespace" (include "db.namespace" .) "image" (.Values.hooks.dbResourcesCleanup.image | default .Values.hooks.image)) }}
 {{- end }}

--- a/charts/everest/charts/everest-db-namespace/values.yaml
+++ b/charts/everest/charts/everest-db-namespace/values.yaml
@@ -1,7 +1,7 @@
 # -- Configuration for Helm chart hooks.
 hooks:
   # -- Default image to use for the Helm chart hooks job.
-  # @default -- `registry.k8s.io/kubectl`
+  # @default -- `bitnamilegacy/kubectl`
   image: bitnamilegacy/kubectl
   # -- Configuration for the CSV cleanup job.
   csvCleanup: {}

--- a/charts/everest/charts/everest-db-namespace/values.yaml
+++ b/charts/everest/charts/everest-db-namespace/values.yaml
@@ -1,3 +1,26 @@
+# -- Configuration for Helm chart hooks.
+hooks:
+  # -- Default image to use for the Helm chart hooks job.
+  # @default -- `registry.k8s.io/kubectl`
+  image: bitnamilegacy/kubectl
+  # -- Configuration for the CSV cleanup job.
+  csvCleanup: {}
+    # -- Image to use for the CSV cleanup job.
+    # If not set, uses the value of `hooks.image`.
+    # image: ""
+
+  # -- Configuration for the DB resources cleanup job.
+  dbResourcesCleanup: {}
+    # -- Image to use for the DB resources cleanup job.
+    # If not set, uses the value of `hooks.image`.
+    # image: ""
+
+  # -- Configuration for the operators installer job.
+  operatorsInstaller: {}
+    # -- Image to use for the operators installer job.
+    # If not set, uses the value of `hooks.image`.
+    # image: ""
+
 compatibility:
   # -- If set, enable OpenShift compatibility.
   openshift: false

--- a/charts/everest/templates/hooks.yaml
+++ b/charts/everest/templates/hooks.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.upgrade.preflightChecks }}
-{{- include "everest.preUpgradeChecks" (dict "namespace" (include "everest.namespace" .) "version" .Chart.Version "versionMetadataURL" (include "everest.versionMetadataURL" .)) }}
+{{- include "everest.preUpgradeChecks" (dict "namespace" (include "everest.namespace" .) "version" .Chart.Version "versionMetadataURL" (include "everest.versionMetadataURL" .) "image" (.Values.hooks.upgradeChecks.image | default .Values.hooks.image)) }}
 {{- end }}
 ---
 {{- /*
@@ -12,5 +12,5 @@
 {{- end }}
 
 {{- /* #  Cleanup all default pod scheduling policies during uninstall. */}}
-{{- include "everest.pspCleanup" (dict "namespace" (include "everest.namespace" .)) }}
+{{- include "everest.pspCleanup" (dict "namespace" (include "everest.namespace" .) "image" (.Values.hooks.pspCleanup.image | default .Values.hooks.image)) }}
 ---

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -1,7 +1,7 @@
 # -- Configuration for Helm chart hooks.
 hooks:
   # -- Default image to use for the Helm chart hooks job.
-  # @default -- `registry.k8s.io/kubectl`
+  # @default -- `bitnamilegacy/kubectl`
   image: bitnamilegacy/kubectl
   pspCleanup: {}
     # -- Image to use for the PSP cleanup job.

--- a/charts/everest/values.yaml
+++ b/charts/everest/values.yaml
@@ -1,3 +1,18 @@
+# -- Configuration for Helm chart hooks.
+hooks:
+  # -- Default image to use for the Helm chart hooks job.
+  # @default -- `registry.k8s.io/kubectl`
+  image: bitnamilegacy/kubectl
+  pspCleanup: {}
+    # -- Image to use for the PSP cleanup job.
+    # If not set, uses the value of `hooks.image`.
+    # image: ""
+  upgradeChecks:
+    # -- Image to use for the upgrade checks job.
+    # If not set, uses the value of `hooks.image`.
+    # @default -- `alpine:3.20`
+    image: "alpine:3.20"
+
 compatibility:
   # -- Enable OpenShift compatibility.
   openshift: false


### PR DESCRIPTION
### Problem

Everest Helm chart uses the `bitnami/kubectl` Docker image to execute some chart hooks. However, the `bitnami` registry is planned for deletion - https://github.com/bitnami/charts/issues/35164

### Solution

- move to `bitnamilegacy/kubectl` temporarily. We might eventually need to build are own image, but this will buy us some extra time
- provide a way to override the image used in the chart hook so that we are not so tightly dependent on an external vendor, and have the flexibility to use alternate images in such situations