### PR TITLE
PMM-14364 Fix Patroni's pg_hba subnets

### DIFF
--- a/charts/pmm-ha/charts/pg-db/values.yaml
+++ b/charts/pmm-ha/charts/pg-db/values.yaml
@@ -494,13 +494,9 @@ patroni:
 #   # - failureThreshold: leaderLeaseDurationSeconds / syncPeriodSeconds.
 #   syncPeriodSeconds: 10
 #   leaderLeaseDurationSeconds: 30
-   dynamicConfiguration:
-     postgresql:
-       pg_hba:
-         - host all gfuser 10.1.0.0/8 md5
-         - host all pmmuser 10.1.0.0/8 md5
-         - host all gfuser 172.17.0.0/8 md5
-         - host all pmmuser 172.17.0.0/8 md5
+#   dynamicConfiguration:
+#     postgresql:
+#       pg_hba: []
 
 #   switchover:
 #     enabled: "true"

--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -376,6 +376,20 @@ pg-db:
                 labelSelector:
                   matchLabels:
                     postgres-operator.crunchydata.com/role: pgbouncer
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        pg_hba:
+          # Allow connections from private RFC1918 networks (common Kubernetes ranges)
+          # 10.0.0.0/8 covers AWS and GCP
+          # 172.16.0.0/12 covers Azure and Docker
+          # 192.168.0.0/16 covers minikube and many on-prem setups
+          - host all gfuser 10.0.0.0/8 md5
+          - host all pmmuser 10.0.0.0/8 md5
+          - host all gfuser 172.16.0.0/12 md5
+          - host all pmmuser 172.16.0.0/12 md5
+          - host all gfuser 192.168.0.0/16 md5
+          - host all pmmuser 192.168.0.0/16 md5
 
 victoria-metrics-cluster:
   vmselect:


### PR DESCRIPTION
This pull request updates the PostgreSQL host-based authentication (pg_hba) configuration for Patroni to better support common private network ranges used in Kubernetes environments. The main change is a shift from hardcoded network ranges to a more flexible and comprehensive configuration that covers major cloud providers and on-prem setups.

**Patroni configuration updates:**

* In `charts/pmm-ha/values.yaml`, the `pg_hba` entries under `patroni.dynamicConfiguration.postgresql` have been updated to allow connections from RFC1918 private networks (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) for both `gfuser` and `pmmuser`, improving compatibility with AWS, GCP, Azure, Docker, minikube, and on-prem environments.

* In `charts/pmm-ha/charts/pg-db/values.yaml`, the previous hardcoded `pg_hba` entries for specific subnets have been replaced with an empty list, delegating the configuration to the parent chart and preventing conflicting or redundant settings.