### PR TITLE
EVEREST-2365 | provide mechanism to skip validating/mutating webhooks

### DIFF
--- a/charts/everest/templates/everest-operator/loadbalancerconfig.yaml
+++ b/charts/everest/templates/everest-operator/loadbalancerconfig.yaml
@@ -6,6 +6,9 @@ metadata:
     "helm.sh/resource-policy": keep
   finalizers:
     - everest.percona.com/readonly-protection
+  labels:
+    everest.percona.com/skip-validating-webhook: "true"
+    everest.percona.com/skip-mutating-webhook: "true"
 spec:
   annotations:
     "service.beta.kubernetes.io/aws-load-balancer-type": "nlb"

--- a/charts/everest/templates/everest-operator/webhook.yaml
+++ b/charts/everest/templates/everest-operator/webhook.yaml
@@ -27,6 +27,12 @@ webhooks:
     resources:
     - splithorizondnsconfigs
   sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - key: everest.percona.com/skip-validating-webhook
+      operator: NotIn
+      values:
+      - "true"
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -48,6 +54,12 @@ webhooks:
     resources:
     - databaseclusters
   sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - key: everest.percona.com/skip-validating-webhook
+      operator: NotIn
+      values:
+      - "true"
 - admissionReviewVersions:
     - v1
   clientConfig:
@@ -69,6 +81,12 @@ webhooks:
       resources:
         - monitoringconfigs
   sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - key: everest.percona.com/skip-validating-webhook
+      operator: NotIn
+      values:
+      - "true"
 - admissionReviewVersions:
     - v1
   clientConfig:
@@ -91,6 +109,12 @@ webhooks:
       resources:
         - loadbalancerconfigs
   sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - key: everest.percona.com/skip-validating-webhook
+      operator: NotIn
+      values:
+      - "true"
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -118,6 +142,12 @@ webhooks:
     resources:
     - splithorizondnsconfigs
   sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - key: everest.percona.com/skip-mutating-webhook
+      operator: NotIn
+      values:
+      - "true"
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -139,6 +169,12 @@ webhooks:
     resources:
     - databaseclusters
   sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - key: everest.percona.com/skip-mutating-webhook
+      operator: NotIn
+      values:
+      - "true"
 - admissionReviewVersions:
   - v1
   clientConfig:
@@ -160,6 +196,12 @@ webhooks:
     resources:
     - dataimportjobs
   sideEffects: None
+  objectSelector:
+    matchExpressions:
+    - key: everest.percona.com/skip-mutating-webhook
+      operator: NotIn
+      values:
+      - "true"
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
#### Problem

Everest cannot be installed using Helm v4.

#### Cause

Helm v4 introduces a breaking change in the manifest installation order. In Helm v3, `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` resources were not considered during resource ordering. As a result, the `LoadBalancerConfig` manifest was applied before the webhook configuration (due to alphabetical ordering of resource kinds), so it was not subject to admission review.

With Helm v4, these webhook configurations are now taken into account, and all unknown resource kinds (such as `LoadBalancerConfig`) are applied *after* the webhook. Since `LoadBalancerConfig` is subject to admission review by our `ValidatingWebhookConfiguration`, the installation fails because the Everest operator is not yet running when the webhook is invoked.

#### Solution

Admission webhooks are now configured to skip validation for objects that have specific labels. This allows the `LoadBalancerConfig` to be created during installation without triggering admission review.