### PR TITLE
fix(pmm): cluster role indentation for included labels should be 4

### DIFF
--- a/charts/pmm/Chart.yaml
+++ b/charts/pmm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pmm
 description: A Helm chart for Percona Monitoring and Management (PMM)
 type: application
-version: 1.4.14
+version: 1.4.15
 appVersion: "3.5.0"
 home: https://github.com/percona/pmm
 maintainers:

--- a/charts/pmm/templates/clusterrole.yaml
+++ b/charts/pmm/templates/clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "pmm.fullname" . }}
     {{- include "pmm.includeNamespace" . | nindent 2 }}
   labels:
-    {{- include "pmm.labels" . | nindent 2 }}
+    {{- include "pmm.labels" . | nindent 4 }}
 rules:
 # standard RBAC
 - apiGroups: [""] # "" indicates the core API group


### PR DESCRIPTION
The labels are currently incorrectly indented resulting in the labels themselves landing at the same layer as the `labels` key. This bumps them out 2 more to be correctly indented.

old:
```yaml
---
# Source: pmm/templates/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test-pmm
  namespace: bootstrapping-operator
  labels:
  helm.sh/chart: pmm-1.4.14
  app.kubernetes.io/name: pmm
  app.kubernetes.io/instance: test
  app.kubernetes.io/component: pmm-server
  app.kubernetes.io/part-of: percona-platform
  app.kubernetes.io/version: "3.5.0"
  app.kubernetes.io/managed-by: Helm
```


new:
```yaml
# Source: pmm/templates/clusterrole.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test-pmm
  namespace: bootstrapping-operator
  labels:
    helm.sh/chart: pmm-1.4.14
    app.kubernetes.io/name: pmm
    app.kubernetes.io/instance: test
    app.kubernetes.io/component: pmm-server
    app.kubernetes.io/part-of: percona-platform
    app.kubernetes.io/version: "3.5.0"
    app.kubernetes.io/managed-by: Helm
```