### PR TITLE
PMM-14634 Use Managed PG database as PMM storage

### DIFF
--- a/charts/pmm-ha/templates/_helpers.tpl
+++ b/charts/pmm-ha/templates/_helpers.tpl
@@ -153,3 +153,15 @@ Example output for 3 replicas:
   port: 2181
 {{- end -}}
 {{- end -}}
+
+{{/*
+Generate PostgreSQL address for PMM
+If PMM_POSTGRES_ADDR is defined in pmmEnv, use it, otherwise use default
+*/}}
+{{- define "pmm.postgresql.address" -}}
+{{- if and .Values.pmmEnv .Values.pmmEnv.PMM_POSTGRES_ADDR -}}
+{{- .Values.pmmEnv.PMM_POSTGRES_ADDR -}}
+{{- else -}}
+{{- .Release.Name }}-pg-db-ha.{{ .Release.Namespace }}.svc.cluster.local:5432
+{{- end -}}
+{{- end -}}

--- a/charts/pmm-ha/templates/statefulset.yaml
+++ b/charts/pmm-ha/templates/statefulset.yaml
@@ -160,7 +160,7 @@ spec:
             - name: PMM_CLICKHOUSE_CLUSTER_NAME
               value: "{{ .Values.clickhouse.cluster.name }}"
             - name: PMM_POSTGRES_ADDR
-              value: "{{ .Release.Name }}-pg-db-ha.{{ .Release.Namespace }}.svc.cluster.local:5432"
+              value: "{{ include "pmm.postgresql.address" . }}"
             - name: PMM_HA_PEERS
               value: "{{ include "pmm.haPeers" . }}"
             - name: PMM_CLICKHOUSE_NODES


### PR DESCRIPTION
HA installations of PMM could use managed databases like Amazon RDS or Aurora as a storage instead of one bundled with PMM HA installation. While bundled solution is the best option in many cases, external database could be helpful for already established infrastructure with all databases running outside of Kubernetes cluster.