### PR TITLE
fix(pg-db): use scram-sha-256 auth instead of md5 for PostgreSQL

### DIFF
--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -638,12 +638,13 @@ pg-db:
           # 10.0.0.0/8 covers AWS and GCP
           # 172.16.0.0/12 covers Azure and Docker
           # 192.168.0.0/16 covers minikube and many on-prem setups
-          - host all gfuser 10.0.0.0/8 md5
-          - host all pmmuser 10.0.0.0/8 md5
-          - host all gfuser 172.16.0.0/12 md5
-          - host all pmmuser 172.16.0.0/12 md5
-          - host all gfuser 192.168.0.0/16 md5
-          - host all pmmuser 192.168.0.0/16 md5
+          # Using scram-sha-256 to match PostgreSQL 14+ default password_encryption
+          - host all gfuser 10.0.0.0/8 scram-sha-256
+          - host all pmmuser 10.0.0.0/8 scram-sha-256
+          - host all gfuser 172.16.0.0/12 scram-sha-256
+          - host all pmmuser 172.16.0.0/12 scram-sha-256
+          - host all gfuser 192.168.0.0/16 scram-sha-256
+          - host all pmmuser 192.168.0.0/16 scram-sha-256
   
   ## @param pg-db.pmm PMM integration for PostgreSQL monitoring
   ## When enabled, PostgreSQL pods will push metrics directly to PMM Server


### PR DESCRIPTION
## Summary
- PostgreSQL 14+ defaults to password_encryption=scram-sha-256
- pg_hba rules specified md5 authentication  
- MD5 auth cannot verify SCRAM-SHA-256 stored passwords
- Changed pg_hba rules from md5 to scram-sha-256

## Root Cause
Authentication failures for pmmuser and gfuser:
```
pq: password authentication failed for user "pmmuser"
```

The passwords matched in both secrets (pmm-secret and pmmuser-credentials), but authentication still failed because:
- PostgreSQL stored passwords as SCRAM-SHA-256
- pg_hba.conf specified md5 authentication method

## Testing
Verified fix on live ROSA HCP cluster - PMM pods became Ready after patching Patroni config.