### PR TITLE
PMM-14788 Increase memory resources for ClickHouse

### DIFF
--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -399,11 +399,11 @@ clickhouse:
   # ClickHouse server resource configuration
   resources:
     requests:
-      memory: "1Gi"
-      cpu: "500m"
-    limits:
       memory: "4Gi"
       cpu: "2"
+    limits:
+      memory: "8Gi"
+      cpu: "4"
   
   cluster:
     # Cluster name restrictions: alphanumeric only, max 15 chars, no underscores


### PR DESCRIPTION
[PMM-14788](https://perconadev.atlassian.net/browse/PMM-14788)

This pull request increases the resource allocation for the ClickHouse server in the `charts/pmm-ha/values.yaml` file, allowing for higher memory and CPU usage. This change will enable ClickHouse to handle larger workloads and improve performance.

Resource allocation updates:

* Increased the `limits` for ClickHouse server resources to `8Gi` memory and `4` CPU, up from `4Gi` and `2` respectively.
* Removed the explicit `requests` for memory and CPU, which previously reserved `1Gi` memory and `500m` CPU.

[PMM-14788]: https://perconadev.atlassian.net/browse/PMM-14788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ