### PR TITLE
PMM-14821 - Add Helm repositories and build chart dependencies in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,17 @@ jobs:
         with:
           version: v3.15.4
 
+      - name: Add Helm repositories
+        run: |
+          helm repo add victoriametrics https://victoriametrics.github.io/helm-charts/
+          helm repo add altinity https://helm.altinity.com
+          helm repo add percona https://percona.github.io/percona-helm-charts/
+          helm repo update
+
+      - name: Build chart dependencies
+        run: |
+          helm dependency build charts/pmm-ha-dependencies
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         env:


### PR DESCRIPTION
pmm-ha-dependencies chart has a few dependencies and because of that the release job is now failing on github.

`Looking up latest tag...
Discovering changed charts since 'everest-1.13.0'...
Installing chart-releaser on /opt/hostedtoolcache/cr/v1.6.1/x86_64...
Adding cr directory to PATH...
Packaging chart 'charts/pmm-ha-dependencies'...
Error: no repository definition for https://victoriametrics.github.io/helm-charts/, https://helm.altinity.com,/ https://percona.github.io/percona-helm-charts/`

I am adding this dependencies to the `release.yaml`. That should not impact the other charts, because charts that don't have external dependencies simply won't use those repos. And for charts that do have dependencies, having the repos registered just means Helm can resolve them if needed. 