### PR TITLE
Update fluentbit image tag to 4.0.1-1 for arm64 support

### DIFF
--- a/charts/psmdb-db/values.yaml
+++ b/charts/psmdb-db/values.yaml
@@ -794,7 +794,7 @@ logcollector:
   enabled: true
   image:
     repository: percona/fluentbit
-    tag: 4.0.1
+    tag: 4.0.1-1
 #  configuration: |
 #    [SERVICE]
 #        Flush        1


### PR DESCRIPTION
Change logcollector fluentbit image tag from 4.0.1 to 4.0.1-1. 
The 4.0.1-1 tag includes arm64 architecture support and is the default version used elsewhere in the project.