### PR TITLE
Fix chart test rule for PG and PXC

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,11 +56,14 @@ jobs:
             for operator in $OPERATOR_INSTALL; do
               HELM_ARGS=()
               if [[ "$GITHUB_BASE_REF" == release-* ]]; then
-                IMAGE_NAME=$(yq e '.image.repository' "charts/$operator/values.yaml" | awk -F/ '{print $NF}')
+                IMAGE_NAME=$(yq e '.operatorImageRepository // .image.repository' "charts/$operator/values.yaml" | awk -F/ '{print $NF}')
                 HELM_ARGS=(
                   --set "image.repository=perconalab/$IMAGE_NAME"
                   --set "image.tag=main"
+                  --set "operatorImageRepository=perconalab/$IMAGE_NAME"
+                  --set "image=perconalab/$IMAGE_NAME:main"
                 )
+                echo "${HELM_ARGS[@]}"
               fi
               helm install --namespace default $operator charts/$operator/. --wait --debug "${HELM_ARGS[@]}"
               excluded_charts+=($operator)


### PR DESCRIPTION
PS, PSMDB and PXC, PG have different definitions for operator repository and image:

PS/PSMDB:
```
image:
     repository:
     tag:
```

PXC/PG:
```
operatorImageRepository:
image:
```

In this case, introduced a search for all operator variants to define operator image repository.