### PR TITLE
[psmdb-db]: pass pmm.mongodParams and mongosParams through tpl function

### DIFF
--- a/charts/psmdb-db/templates/cluster.yaml
+++ b/charts/psmdb-db/templates/cluster.yaml
@@ -128,10 +128,10 @@ spec:
     image: "{{ .Values.pmm.image.repository }}:{{ .Values.pmm.image.tag }}"
     serverHost: {{ .Values.pmm.serverHost }}
     {{- if .Values.pmm.mongodParams }}
-    mongodParams: {{ .Values.pmm.mongodParams }}
+    mongodParams: {{ tpl .Values.pmm.mongodParams $ }}
     {{- end }}
     {{- if .Values.pmm.mongosParams }}
-    mongosParams: {{ .Values.pmm.mongosParams }}
+    mongosParams: {{ tpl .Values.pmm.mongosParams $ }}
     {{- end }}
     {{- if .Values.pmm.resources }}
     resources:


### PR DESCRIPTION
## Description

Pass `pmm.mongodParams` and `pmm.mongosParams` through the `tpl` function so they can reference Helm template variables (e.g. `.Values.global.environment`).

This allows users to avoid duplicating the full parameter string per cluster and instead template dynamic values like environment name:

```yaml
# values.yaml
pmm:
  mongodParams: "--environment={{ .Values.global.environment }} --collector.diagnosticdata"
  mongosParams: "--environment={{ .Values.global.environment }}"
```

Follows the same pattern as #777 which did this for `replset.configuration`.

## Changes

- `cluster.yaml`: wrap `pmm.mongodParams` and `pmm.mongosParams` with `tpl` (same as `replset.configuration` in #777)
