### PR TITLE
K8SPSMDB-1742 Publish charts as OCI artifacts to GHCR

### DIFF
--- a/.github/workflows/everest-release.yaml
+++ b/.github/workflows/everest-release.yaml
@@ -17,10 +17,6 @@ jobs:
       # Is set if the VERSION corresponds to an RC.
       IS_RC: 0
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # to push chart release and create a release (helm/chart-releaser-action)
-      packages: write # needed for ghcr access
-      id-token: write # needed for keyless signing
     steps:
       - name: Set environment variables
         run: |
@@ -69,18 +65,3 @@ jobs:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-      # see https://github.com/helm/chart-releaser/issues/183
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4.1.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push charts to GHCR
-        run: |
-          shopt -s nullglob
-          for pkg in .cr-release-packages/*.tgz; do
-            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/percona-helm-charts"
-          done

--- a/.github/workflows/everest-release.yaml
+++ b/.github/workflows/everest-release.yaml
@@ -17,6 +17,10 @@ jobs:
       # Is set if the VERSION corresponds to an RC.
       IS_RC: 0
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
+      id-token: write # needed for keyless signing
     steps:
       - name: Set environment variables
         run: |
@@ -65,3 +69,18 @@ jobs:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/percona-helm-charts"
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
+      id-token: write # needed for keyless signing
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -51,3 +55,18 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           skip_existing: true
+
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/percona-helm-charts"
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to push chart release and create a release (helm/chart-releaser-action)
+      packages: write # needed for ghcr access
+      id-token: write # needed for keyless signing
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -46,3 +50,18 @@ jobs:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           skip_existing: true
+
+      # see https://github.com/helm/chart-releaser/issues/183
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        run: |
+          shopt -s nullglob
+          for pkg in .cr-release-packages/*.tgz; do
+            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/percona-helm-charts"
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,21 @@ jobs:
       - name: Push charts to GHCR
         run: |
           shopt -s nullglob
+          repo="oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/percona-helm-charts"
+          failed=()
           for pkg in .cr-release-packages/*.tgz; do
-            helm push "${pkg}" "oci://ghcr.io/${GITHUB_REPOSITORY_OWNER}/percona-helm-charts"
+            pushed=false
+            for attempt in 1 2 3; do
+              if helm push "${pkg}" "${repo}"; then
+                pushed=true
+                break
+              fi
+              echo "::warning::helm push ${pkg} failed (attempt ${attempt}/3)"
+              sleep $((attempt * 5))
+            done
+            "${pushed}" || failed+=("${pkg}")
           done
+          if [ "${#failed[@]}" -ne 0 ]; then
+            echo "::error::failed to push ${#failed[@]} chart(s): ${failed[*]}"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Useful links:
 
 You will need [Helm v3](https://github.com/helm/helm) for the installation. See detailed installation instructions in the README file of each chart.
 
+OCI artifacts of all Percona Helm charts are also available from [ghcr.io](https://github.com/orgs/percona/packages?repo_name=percona-helm-charts) and can be installed directly:
+
+```console
+helm install [RELEASE_NAME] oci://ghcr.io/percona/percona-helm-charts/[CHART_NAME]
+```
+
 # Need help?
 
 |                                                                                                         **Commercial Support**                                                                                                         |                                                       **Community Support**                                                        |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Useful links:
 
 You will need [Helm v3](https://github.com/helm/helm) for the installation. See detailed installation instructions in the README file of each chart.
 
+OCI artifacts of all Percona Helm charts are also available from [ghcr.io](https://github.com/orgs/percona/packages?repo_name=percona-helm-charts) and can be installed directly:
+
+```console
+helm install [RELEASE_NAME] oci://ghcr.io/percona/percona-helm-charts/[CHART_NAME]
+```
+
 ## Testing Charts
 
 This repository uses the [helm-unittest](https://github.com/helm-unittest/helm-unittest) plugin for chart unit tests.


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/K8SPSMDB-1742

## Summary
- After `chart-releaser-action` runs, log in to `ghcr.io` and push every newly-released package from `.cr-release-packages/*.tgz` to `oci://ghcr.io/percona/percona-helm-charts`.
- Document the OCI install path in the top-level README.

Closes #721

## Test plan
- [ ] Merge to `main` triggers `Release Charts`; verify chart-releaser still creates the GitHub release as before.
- [ ] Verify the new "Push charts to GHCR" step pushes only the newly-released packages and that the resulting artifacts appear at https://github.com/orgs/percona/packages?repo_name=percona-helm-charts.
- [ ] Confirm `helm pull oci://ghcr.io/percona/percona-helm-charts/<chart> --version <version>` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)