### PR TITLE
PMM-14851 Fix ClusterRole template

### DIFF
--- a/charts/pmm/Chart.yaml
+++ b/charts/pmm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pmm
 description: A Helm chart for Percona Monitoring and Management (PMM)
 type: application
-version: 1.6.1
+version: 1.6.2
 appVersion: "3.7.1"
 home: https://github.com/percona/pmm
 maintainers:

--- a/charts/pmm/templates/clusterrole.yaml
+++ b/charts/pmm/templates/clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "pmm.fullname" . }}
-    {{- include "pmm.includeNamespace" . | nindent 2 }}
   labels:
     {{- include "pmm.labels" . | nindent 2 }}
 rules:

--- a/charts/pmm/templates/clusterrole.yaml
+++ b/charts/pmm/templates/clusterrole.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   name: {{ include "pmm.fullname" . }}
   labels:
-    {{- include "pmm.labels" . | nindent 2 }}
+    {{- include "pmm.labels" . | nindent 4 }}
 rules:
 # standard RBAC
 - apiGroups: [""] # "" indicates the core API group


### PR DESCRIPTION
[PMM-14851](https://perconadev.atlassian.net/browse/PMM-14851)

 - Remove the namespace from the ClusterRole template since it's cluster-wide resource and cannot be namespaced
 - Fix the indentation of the `pmm.labels`

[PMM-14851]: https://perconadev.atlassian.net/browse/PMM-14851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Closes #833
Closes #834
Closes #762 