### PR TITLE
Update GH actions versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,9 +27,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@v4.3.1
         with:
-          version: v3.15.4
+          version: v3.21.0
 
       - name: Add Helm repositories
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,14 +21,14 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v4.3.1
         with:
-          version: v3.20.0
+          version: v3.21.0
 
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.13'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -42,7 +42,7 @@ jobs:
         run: ct lint --config .github/ct.yaml --lint-conf .github/lintconf.yaml --excluded-charts=everest,pmm-ha,pmm-ha-dependencies
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.10.0
+        uses: helm/kind-action@v1.14.0
         # Only build a kind cluster if there are chart changes to test.
         if: steps.list-changed.outputs.changed == 'true'
 


### PR DESCRIPTION
Updates GitHub Actions tooling versions in the main chart CI and release workflows.

**.github/workflows/test.yaml (Lint and Test Charts)**

Helm: v3.20.0 → v3.21.0
Python: 3.9 → 3.13
helm/chart-testing-action: v2.6.1 → v2.8.0
helm/kind-action: v1.10.0 → v1.14.0
(azure/setup-helm@v4.3.1 was already in use; only the Helm version pin changed.)

**.github/workflows/release.yaml (Release Charts)**

azure/setup-helm: v4.2.0 → v4.3.1
Helm: v3.15.4 → v3.21.0