### PR TITLE
fix(pmm): set gRPC service to ClusterIP to avoid duplicate nodePort conflict

### DIFF
--- a/charts/pmm/Chart.yaml
+++ b/charts/pmm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pmm
 description: A Helm chart for Percona Monitoring and Management (PMM)
 type: application
-version: 1.9.1
+version: 1.9.2
 appVersion: "3.9.1"
 home: https://github.com/percona/pmm
 maintainers:

--- a/charts/pmm/templates/service.yaml
+++ b/charts/pmm/templates/service.yaml
@@ -40,10 +40,15 @@ metadata:
     {{- toYaml . | nindent 8 }}
   {{- end }}
 spec:
-  type: {{ $serviceType | default "ClusterIP" }}
+  # The gRPC service is only consumed internally as an Ingress backend, so it is
+  # always ClusterIP. Inheriting the main service type (e.g. NodePort) would make
+  # both services request the same nodePort values and fail to deploy.
+  type: ClusterIP
   {{- with .Values.service.ports }}
   ports:
-    {{- toYaml . | nindent 8 }}
+    {{- range . }}
+    {{- toYaml (list (omit . "nodePort")) | nindent 8 }}
+    {{- end }}
   {{- end }}
   selector:
     {{- include "pmm.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
The `-grpc` service created when `ingress.enabled=true` inherited the main
`service.type`. With `service.type: NodePort` and explicit
`service.ports[].nodePort` values, both `monitoring-service` and
`monitoring-service-grpc` requested the same nodePorts, so the second service
failed to deploy (a nodePort can only be claimed by one service).

The `-grpc` service is only referenced as an internal Ingress backend (see
`templates/ingress.yaml`), so it never needs to be NodePort/LoadBalancer. This
sets it to `ClusterIP` and drops the `nodePort` field from its ports, which also
avoids a redundant second LoadBalancer when `service.type: LoadBalancer`.

Validation (helm template, chart pmm-1.8.1):
- Default (ingress disabled): only `monitoring-service` rendered, unchanged.
- NodePort + explicit nodePort + ingress enabled: `monitoring-service` keeps its
  nodePorts; `monitoring-service-grpc` renders as ClusterIP with no nodePort — no conflict.
- service.type=ClusterIP + ingress enabled: both ClusterIP, unchanged.
- `helm lint` and `ct lint` pass.

closes: #723

---

Drafted with Claude Code (Opus 4.8) and manually reviewed.