### PR TITLE
make affinity optional for cluster resource

### DIFF
--- a/charts/pxc-db/Chart.yaml
+++ b/charts/pxc-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.20.0
 description: A Helm chart for installing Percona XtraDB Cluster Databases using the PXC Operator.
 name: pxc-db
 home: https://www.percona.com/doc/kubernetes-operator-for-pxc/kubernetes.html
-version: 1.20.0
+version: 1.20.1
 maintainers:
   - name: eleo007
     email: eleonora.zinchenko@percona.com

--- a/charts/pxc-db/templates/cluster.yaml
+++ b/charts/pxc-db/templates/cluster.yaml
@@ -213,8 +213,10 @@ spec:
     topologySpreadConstraints:
 {{ $pxc.topologySpreadConstraints | toYaml | indent 6 }}
     {{- end }}
+    {{- with $pxc.affinity }}
     affinity:
-{{ $pxc.affinity | toYaml | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     tolerations:
 {{ $pxc.tolerations | toYaml | indent 6 }}
     podDisruptionBudget:
@@ -349,8 +351,10 @@ spec:
     topologySpreadConstraints:
 {{ $haproxy.topologySpreadConstraints | toYaml | indent 6 }}
     {{- end }}
+    {{- with $haproxy.affinity }}
     affinity:
-{{ $haproxy.affinity | toYaml | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     tolerations:
 {{ $haproxy.tolerations | toYaml | indent 6 }}
     podDisruptionBudget:
@@ -473,8 +477,10 @@ spec:
     topologySpreadConstraints:
 {{ $proxysql.topologySpreadConstraints | toYaml | indent 6 }}
     {{- end }}
+    {{- with $proxysql.affinity }}
     affinity:
-{{ $proxysql.affinity | toYaml | indent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     tolerations:
 {{ $proxysql.tolerations | toYaml | indent 6 }}
     podDisruptionBudget:


### PR DESCRIPTION
This PR will make the affinity parameters optional, allowing users to specify `affinity: null` and not pass in any sort of affinity. This is useful when testing in CI with a single node, for instance. Each instance of affinity in the cluster.yaml has been updated to look like this for instance:

```go
    {{- with $haproxy.affinity }}
    affinity:
      {{- toYaml . | nindent 6 }}
    {{- end }}
```

In helm's gotemplating `with` is an implicit `if`, so if `affinity` is not present, it will not template this parameter at all. I've also updated the indentation, and since every `{{` has a hyphen after it, it will default remove all white space before applying the what's in the curly braces. In the above case, `toYaml . | nindent 6`, will convert everything in the `$haproxy.affinity` variable to YAML and then it will skip a line, and indent 6 spaces. This will result in:

```yaml
  haproxy:
    affinity:
      antiAffinityTopologyKey: kubernetes.io/hostname
```

This makes sure to still retain the previous functionality of the chart.