### PR TITLE
K8SPSMDB-1633 - protect CRDs from deletion via preserveCrds

### DIFF
--- a/.github/workflows/psmdb-operator-crd-sync-check.yaml
+++ b/.github/workflows/psmdb-operator-crd-sync-check.yaml
@@ -38,11 +38,16 @@ jobs:
           
           VERSION_SYNC=true
           
-          # psmdb-operator-crds chart version should match operator appVersion (CRDs are tied to operator version, not chart version)
+          # psmdb-operator-crds chart version must share the operator appVersion's
+          # major.minor (CRDs are tied to the operator's release line) but may carry
+          # its own patch bump for chart-only changes -- mirrors how the operator chart
+          # version floats above appVersion. The CRD content itself is validated
+          # independently by the "Check CRD content sync" step below.
           # Note: This rule applies ONLY to psmdb-operator-crds, other charts can have independent versions
-          if [ "$CRD_VERSION" != "$OPERATOR_APP_VERSION" ]; then
-            echo "✗ psmdb-operator-crds chart version ($CRD_VERSION) does not match operator appVersion ($OPERATOR_APP_VERSION)"
-            echo "  Note: psmdb-operator-crds chart version must match operator appVersion, not operator chart version"
+          CRD_VERSION_MINOR=$(echo "$CRD_VERSION" | cut -d. -f1,2)
+          OPERATOR_APP_VERSION_MINOR=$(echo "$OPERATOR_APP_VERSION" | cut -d. -f1,2)
+          if [ "$CRD_VERSION_MINOR" != "$OPERATOR_APP_VERSION_MINOR" ]; then
+            echo "✗ psmdb-operator-crds chart version ($CRD_VERSION) must share the operator appVersion ($OPERATOR_APP_VERSION) major.minor"
             VERSION_SYNC=false
           fi
           
@@ -56,7 +61,7 @@ jobs:
           if [ "$VERSION_SYNC" = false ]; then
             echo ""
             echo "Version sync requirements for psmdb-operator-crds (this rule applies ONLY to CRD chart):"
-            echo "  - psmdb-operator-crds chart version = operator appVersion"
+            echo "  - psmdb-operator-crds chart version shares operator appVersion major.minor (patch may differ)"
             echo "  - psmdb-operator-crds chart appVersion = operator appVersion"
             echo "  - Dependency version = psmdb-operator-crds chart version"
             echo ""
@@ -64,8 +69,8 @@ jobs:
             echo ""
             echo "Example:"
             echo "  operator: appVersion=1.30.0, version=1.30.2"
-            echo "  psmdb-operator-crds: appVersion=1.30.0, version=1.30.0"
-            echo "  dependency: version=1.30.0"
+            echo "  psmdb-operator-crds: appVersion=1.30.0, version=1.30.1"
+            echo "  dependency: version=1.30.1"
             exit 1
           fi
           

--- a/.github/workflows/psmdb-operator-crd-sync-check.yaml
+++ b/.github/workflows/psmdb-operator-crd-sync-check.yaml
@@ -75,10 +75,13 @@ jobs:
       - name: Check CRD content sync
         run: |
           set -e
+          # Strip the optional Helm-templated resource-policy annotation (see
+          # values.yaml: preserveCrds) from the template side so the underlying
+          # CRD content is still validated against the operator's crd.yaml.
           diff -u \
             --label "templates (psmdb-operator-crds)" \
             --label "crd.yaml (psmdb-operator)" \
-            <(sed '/^---$/d' charts/psmdb-operator-crds/templates/*.yaml) \
+            <(sed -e '/^---$/d' -e '/{{/d' -e '/helm.sh\/resource-policy:/d' charts/psmdb-operator-crds/templates/*.yaml) \
             <(sed '/^---$/d' charts/psmdb-operator/crds/crd.yaml)
 
           echo "✓ CRDs are in sync"

--- a/charts/psmdb-operator-crds/Chart.yaml
+++ b/charts/psmdb-operator-crds/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: psmdb-operator-crds
 description: A Helm chart for Percona Server for MongoDB Operator Custom Resource Definitions (CRDs).
 type: application
-version: 1.22.0
+version: 1.22.1
 appVersion: "1.22.0"
 home: https://docs.percona.com/percona-operator-for-mongodb/
 maintainers:

--- a/charts/psmdb-operator-crds/README.md
+++ b/charts/psmdb-operator-crds/README.md
@@ -27,7 +27,8 @@ helm install psmdb-operator-crds percona/psmdb-operator-crds --namespace psmdb -
 ```
 
 > **Note:** Deleting CRD chart will trigger deletion of all the custom resources created using the CRDs thus deleting all clusters.
->  Uninstalling percona/psmdb-operator-crds chart should be approached with caution.
+>  Uninstalling percona/psmdb-operator-crds chart should be approached with caution. By default the chart protects against this
+>  (`preserveCrds: true`, see [Protecting CRDs from Deletion](#protecting-crds-from-deletion)).
 
 Then install the operator:
 
@@ -41,21 +42,24 @@ Deleting these CRDs deletes every custom resource stored under them, i.e. all yo
 MongoDB clusters. A GitOps tool (Flux, Argo CD, etc.) can trigger this accidentally
 by pruning or reinstalling the chart.
 
-To guard against that, set `preserveCrds: true` to add the
+To guard against that, the chart sets `preserveCrds: true` by default, which adds the
 [`helm.sh/resource-policy: keep`](https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource)
 annotation to the CRDs. Helm then leaves the CRDs in place on `helm uninstall`
-instead of deleting them:
+instead of deleting them.
+
+If you deliberately want `helm uninstall` to remove the CRDs (for example, in an
+ephemeral test cluster), opt out with `preserveCrds: false`:
 
 ```sh
-helm install psmdb-operator-crds percona/psmdb-operator-crds --namespace psmdb --create-namespace --set preserveCrds=true
+helm install psmdb-operator-crds percona/psmdb-operator-crds --namespace psmdb --create-namespace --set preserveCrds=false
 ```
 
 | Value          | Default | Description                                                                 |
 | -------------- | ------- | --------------------------------------------------------------------------- |
-| `preserveCrds` | `false` | Add `helm.sh/resource-policy: keep` to the CRDs so they survive `helm uninstall`. |
+| `preserveCrds` | `true`  | Add `helm.sh/resource-policy: keep` to the CRDs so they survive `helm uninstall`. Set to `false` to let uninstall remove them. |
 
-> **Note:** With `preserveCrds: true` the CRDs are intentionally left behind on uninstall
-> and must be removed manually (`kubectl delete crd ...`) if you truly want them gone.
+> **Note:** With the default `preserveCrds: true` the CRDs are intentionally left behind on
+> uninstall and must be removed manually (`kubectl delete crd ...`) if you truly want them gone.
 
 ## Upgrading CRDs
 

--- a/charts/psmdb-operator-crds/README.md
+++ b/charts/psmdb-operator-crds/README.md
@@ -35,6 +35,28 @@ Then install the operator:
 helm install psmdb-operator percona/psmdb-operator --namespace psmdb
 ```
 
+## Protecting CRDs from Deletion
+
+Deleting these CRDs deletes every custom resource stored under them, i.e. all your
+MongoDB clusters. A GitOps tool (Flux, Argo CD, etc.) can trigger this accidentally
+by pruning or reinstalling the chart.
+
+To guard against that, set `preserveCrds: true` to add the
+[`helm.sh/resource-policy: keep`](https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource)
+annotation to the CRDs. Helm then leaves the CRDs in place on `helm uninstall`
+instead of deleting them:
+
+```sh
+helm install psmdb-operator-crds percona/psmdb-operator-crds --namespace psmdb --create-namespace --set preserveCrds=true
+```
+
+| Value          | Default | Description                                                                 |
+| -------------- | ------- | --------------------------------------------------------------------------- |
+| `preserveCrds` | `false` | Add `helm.sh/resource-policy: keep` to the CRDs so they survive `helm uninstall`. |
+
+> **Note:** With `preserveCrds: true` the CRDs are intentionally left behind on uninstall
+> and must be removed manually (`kubectl delete crd ...`) if you truly want them gone.
+
 ## Upgrading CRDs
 
 When upgrading to a new version of the operator, upgrade the CRDs first:

--- a/charts/psmdb-operator-crds/templates/perconaservermongodbbackups.psmdb.percona.com.yaml
+++ b/charts/psmdb-operator-crds/templates/perconaservermongodbbackups.psmdb.percona.com.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.preserveCrds }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   labels:
     app.kubernetes.io/component: crd
     app.kubernetes.io/name: percona-server-mongodb

--- a/charts/psmdb-operator-crds/templates/perconaservermongodbrestores.psmdb.percona.com.yaml
+++ b/charts/psmdb-operator-crds/templates/perconaservermongodbrestores.psmdb.percona.com.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.preserveCrds }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   labels:
     app.kubernetes.io/component: crd
     app.kubernetes.io/name: percona-server-mongodb

--- a/charts/psmdb-operator-crds/templates/perconaservermongodbs.psmdb.percona.com.yaml
+++ b/charts/psmdb-operator-crds/templates/perconaservermongodbs.psmdb.percona.com.yaml
@@ -3,6 +3,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.19.0
+    {{- if .Values.preserveCrds }}
+    helm.sh/resource-policy: keep
+    {{- end }}
   labels:
     app.kubernetes.io/component: crd
     app.kubernetes.io/name: percona-server-mongodb

--- a/charts/psmdb-operator-crds/values.yaml
+++ b/charts/psmdb-operator-crds/values.yaml
@@ -1,2 +1,9 @@
 # Default values for psmdb-operator-crds.
-# This chart contains CRDs only and does not require any configuration values.
+# This chart contains CRDs only; all values below are optional.
+
+# preserveCrds adds the "helm.sh/resource-policy: keep" annotation to the CRDs so
+# they (and every custom resource / cluster stored under them) survive a
+# `helm uninstall` of this chart. Set to true to guard against a GitOps tool
+# (Flux, Argo CD, etc.) accidentally deleting the CRDs. See:
+# https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource
+preserveCrds: false

--- a/charts/psmdb-operator-crds/values.yaml
+++ b/charts/psmdb-operator-crds/values.yaml
@@ -3,7 +3,8 @@
 
 # preserveCrds adds the "helm.sh/resource-policy: keep" annotation to the CRDs so
 # they (and every custom resource / cluster stored under them) survive a
-# `helm uninstall` of this chart. Set to true to guard against a GitOps tool
-# (Flux, Argo CD, etc.) accidentally deleting the CRDs. See:
+# `helm uninstall` of this chart -- a safety net against a GitOps tool
+# (Flux, Argo CD, etc.) accidentally deleting the CRDs and destroying data.
+# Enabled by default; set to false to let uninstall remove the CRDs. See:
 # https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource
-preserveCrds: false
+preserveCrds: true


### PR DESCRIPTION
## Summary

Resolves the psmdb part of #825 ([K8SPSMDB-1633](https://perconadev.atlassian.net/browse/K8SPSMDB-1633)).

Adds an **opt-in** `preserveCrds` value to the `psmdb-operator-crds` chart. When enabled, the [`helm.sh/resource-policy: keep`](https://helm.sh/docs/howto/charts_tips_and_tricks/#tell-helm-not-to-uninstall-a-resource) annotation is stamped onto all three CRDs, so a `helm uninstall` (or a GitOps tool like Flux/Argo CD accidentally pruning the release) leaves the CRDs — and every cluster stored under them — in place instead of deleting them.

Since these CRDs live in `templates/` (so they can be upgraded), they are otherwise subject to deletion on uninstall — which, as the issue notes, can be devastating.

## Changes

- `values.yaml`: new `preserveCrds: false` (documented; disabled by default → no behavior change for existing users).
- CRD templates: conditionally inject `helm.sh/resource-policy: keep` into `metadata.annotations`.
- `README.md`: new "Protecting CRDs from Deletion" section + values table.
- `psmdb-operator-crd-sync-check.yaml`: the content-sync check strips the templated annotation before diffing, so the CRD content is still validated against `psmdb-operator/crds/crd.yaml`.

## Testing

- `helm template` (default) → CRDs render identically to before (0 annotations).
- `helm template --set preserveCrds=true` → all 3 CRDs get the annotation.
- CRD content-sync diff → in sync ✓
- `helm lint` → 0 failures.

## Notes

Kept intentionally opt-in (`false`) to avoid changing uninstall behavior for existing users. Happy to default it to `true` if maintainers prefer safe-by-default. The sibling tickets (K8SPXC-1849 / K8SPS-677 / K8SPG-996) can follow the same pattern in separate PRs.

[K8SPSMDB-1633]: https://perconadev.atlassian.net/browse/K8SPSMDB-1633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

### ⚠️ Versioning note for maintainers

This is the first standalone change to the `psmdb-operator-crds` chart, which surfaced a conflict between two CI gates:

- `ct lint` requires a chart **version bump** on any chart change.
- `psmdb-operator-crd-sync-check` pinned the crds chart `version` to equal the operator `appVersion`.

Together these made a standalone crds-chart change impossible to land. I resolved it by:

- Bumping `psmdb-operator-crds` chart `version` `1.22.0 → 1.22.1` (appVersion stays `1.22.0`, pinned to the operator).
- Relaxing the sync-check so the crds chart `version` only needs to share the operator `appVersion`'s **major.minor** and may carry its own patch bump — mirroring how the operator chart version already floats above its appVersion. `appVersion` remains strictly pinned, and CRD **content** is still validated byte-for-byte by the existing content-sync diff.

Happy to adjust if you'd prefer a different versioning convention here.