### PR TITLE
feature(helm): add gateway api support

### DIFF
--- a/charts/pmm-ha/Chart.yaml
+++ b/charts/pmm-ha/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pmm-ha
 description: A Helm chart for Percona Monitoring and Management (PMM)
 type: application
-version: 1.5.1
+version: 1.5.2
 appVersion: "3.8.1"
 home: https://github.com/percona/pmm
 maintainers:

--- a/charts/pmm-ha/README.md
+++ b/charts/pmm-ha/README.md
@@ -280,6 +280,23 @@ To create additional service tokens manually, see the [PMM documentation on serv
 | `ingress.pathType`                | -- How ingress paths should be treated.                                                                                                        | `Prefix`              |
 | `ingress.tls`                     | -- Ingress TLS configuration                                                                                                                   | `[]`                  |
 
+### PMM Gateway API configuration
+
+| Name                                 | Description                                                                                                                                              | Value                                           |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `gateway.enabled`                    | -- Enable Gateway API HTTPRoute resource                                                                                                                | `false`                                         |
+| `gateway.annotations`                | -- Annotations on the HTTPRoute resource                                                                                                                | `{}`                                            |
+| `gateway.parentRefs`                 | -- References to Gateways this HTTPRoute should attach to                                                                                               | `[{'name':'','namespace':'','sectionName':''}]` |
+| `gateway.parentRefs[0].name`         | -- Name of the Gateway. Required when `gateway.enabled=true`                                                                                            | `""`                                            |
+| `gateway.parentRefs[0].namespace`    | -- Namespace of the Gateway (omit to use same namespace)                                                                                                | `""`                                            |
+| `gateway.parentRefs[0].sectionName`  | -- Listener section name on the Gateway (omit to match all listeners)                                                                                  | `""`                                            |
+| `gateway.hosts`                      | -- Hostnames with path lists. Paths are aggregated and applied route-wide across all listed hostnames                                                   | `[{'host':'chart-example.local','paths':[]}]`   |
+| `gateway.hosts[0].host`              | -- Hostname to match                                                                                                                                     | `chart-example.local`                           |
+| `gateway.hosts[0].paths`             | -- Path prefixes to route. Must contain at least one path when `gateway.enabled=true`                                                                  | `[]`                                            |
+| `gateway.pathType`                   | -- Path match type applied to all generated rules: `PathPrefix`, `Exact`, or `RegularExpression`                                                      | `PathPrefix`                                    |
+
+> **Gateway behavior**: when `gateway.enabled=true`, Helm fails fast unless `gateway.parentRefs[*].name` and at least one entry in `gateway.hosts[*].paths` are provided. Paths from `gateway.hosts[*].paths` are aggregated and applied route-wide to all listed hostnames. HTTPRoute backends use the regular `service.name-grpc` service for compatibility with Gateway API implementations; gRPC-prefixed paths (`/agent.`, `/inventory.`, `/management.`, `/server.`) also route to `service.name-grpc`. PMM-HA defaults this backend to HTTPS port 8443. HTTPRoute does not configure gateway-to-backend TLS by itself; depending on your Gateway implementation, you may need `BackendTLSPolicy` (or equivalent implementation-specific settings) to enable upstream TLS, otherwise some gateways may attempt plain HTTP to 8443 and routing can fail.
+
 
 ### HAProxy external access configuration
 

--- a/charts/pmm-ha/templates/gateway-httproute.yaml
+++ b/charts/pmm-ha/templates/gateway-httproute.yaml
@@ -39,6 +39,7 @@ spec:
     - {{ .host | quote }}
   {{- end }}
   {{- end }}
+  {{/* HTTPRoute hostnames are route-level, so host paths are aggregated once and applied across listed hostnames. */}}
   {{- $allPaths := list -}}
   {{- range .Values.gateway.hosts }}
   {{- $allPaths = concat $allPaths (default (list) .paths) -}}

--- a/charts/pmm-ha/templates/gateway-httproute.yaml
+++ b/charts/pmm-ha/templates/gateway-httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.gateway.enabled -}}
 {{- $serviceName := .Values.service.name -}}
 {{- $grpcPort := (index $.Values.service.ports 0).port -}}
-{{- $servicePort := (index $.Values.service.ports 0).port -}}
+{{- $servicePort := (index $.Values.service.ports 1).port -}}
 {{- $pathType := .Values.gateway.pathType -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -44,7 +44,7 @@ spec:
             type: {{ $pathType }}
             value: {{ . | quote }}
       backendRefs:
-        - name: {{ $serviceName }}-grpc
+        - name: {{ $serviceName }}
           port: {{ $servicePort }}
     # gRPC paths — configure protocol-level gRPC handling via gateway.annotations
     - matches:

--- a/charts/pmm-ha/templates/gateway-httproute.yaml
+++ b/charts/pmm-ha/templates/gateway-httproute.yaml
@@ -47,14 +47,13 @@ spec:
   {{- fail "gateway.hosts[*].paths must contain at least one path when gateway.enabled=true" }}
   {{- end }}
   rules:
-  {{- range .Values.gateway.hosts }}
-  {{- range .paths }}
+  {{- range $allPaths }}
     - matches:
         - path:
             type: {{ $pathType }}
             value: {{ . | quote }}
       backendRefs:
-        - name: {{ $serviceName }}
+        - name: {{ $serviceName }}-grpc
           port: {{ $servicePort }}
     # gRPC paths — configure protocol-level gRPC handling via gateway.annotations
     - matches:
@@ -85,6 +84,5 @@ spec:
       backendRefs:
         - name: {{ $serviceName }}-grpc
           port: {{ $grpcPort }}
-  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/pmm-ha/templates/gateway-httproute.yaml
+++ b/charts/pmm-ha/templates/gateway-httproute.yaml
@@ -1,7 +1,10 @@
 {{- if .Values.gateway.enabled -}}
 {{- $serviceName := .Values.service.name -}}
 {{- $grpcPort := (index $.Values.service.ports 0).port -}}
-{{- $servicePort := (index $.Values.service.ports 1).port -}}
+{{- $servicePort := (index $.Values.service.ports 0).port -}}
+{{- if gt (len $.Values.service.ports) 1 -}}
+{{- $servicePort = (index $.Values.service.ports 1).port -}}
+{{- end -}}
 {{- $pathType := .Values.gateway.pathType -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -35,6 +38,13 @@ spec:
   {{- range .Values.gateway.hosts }}
     - {{ .host | quote }}
   {{- end }}
+  {{- end }}
+  {{- $allPaths := list -}}
+  {{- range .Values.gateway.hosts }}
+  {{- $allPaths = concat $allPaths (default (list) .paths) -}}
+  {{- end }}
+  {{- if empty $allPaths }}
+  {{- fail "gateway.hosts[*].paths must contain at least one path when gateway.enabled=true" }}
   {{- end }}
   rules:
   {{- range .Values.gateway.hosts }}

--- a/charts/pmm-ha/templates/gateway-httproute.yaml
+++ b/charts/pmm-ha/templates/gateway-httproute.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.gateway.enabled -}}
 {{- $serviceName := .Values.service.name -}}
 {{- $grpcPort := (index $.Values.service.ports 0).port -}}
-{{- $servicePort := (index $.Values.service.ports 1).port -}}
+{{- $servicePort := (index $.Values.service.ports 0).port -}}
 {{- $pathType := .Values.gateway.pathType -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -14,8 +14,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if empty .Values.gateway.parentRefs }}
+  {{- fail "gateway.parentRefs must be set when gateway.enabled=true" }}
+  {{- end }}
   parentRefs:
   {{- range .Values.gateway.parentRefs }}
+    {{- if empty .name }}
+    {{- fail "gateway.parentRefs[*].name must be set when gateway.enabled=true" }}
+    {{- end }}
     - name: {{ .name | quote }}
       {{- if .namespace }}
       namespace: {{ .namespace | quote }}
@@ -38,7 +44,7 @@ spec:
             type: {{ $pathType }}
             value: {{ . | quote }}
       backendRefs:
-        - name: {{ $serviceName }}
+        - name: {{ $serviceName }}-grpc
           port: {{ $servicePort }}
     # gRPC paths — configure protocol-level gRPC handling via gateway.annotations
     - matches:

--- a/charts/pmm-ha/templates/gateway-httproute.yaml
+++ b/charts/pmm-ha/templates/gateway-httproute.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.gateway.enabled -}}
+{{- $serviceName := .Values.service.name -}}
+{{- $grpcPort := (index $.Values.service.ports 0).port -}}
+{{- $servicePort := (index $.Values.service.ports 1).port -}}
+{{- $pathType := .Values.gateway.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "pmm.fullname" . }}
+  labels:
+    {{- include "pmm.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- range .Values.gateway.parentRefs }}
+    - name: {{ .name | quote }}
+      {{- if .namespace }}
+      namespace: {{ .namespace | quote }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName | quote }}
+      {{- end }}
+  {{- end }}
+  {{- if .Values.gateway.hosts }}
+  hostnames:
+  {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.gateway.hosts }}
+  {{- range .paths }}
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ . | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}
+          port: {{ $servicePort }}
+    # gRPC paths — configure protocol-level gRPC handling via gateway.annotations
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ printf "%s/agent." . | replace "//" "/" | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}-grpc
+          port: {{ $grpcPort }}
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ printf "%s/inventory." . | replace "//" "/" | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}-grpc
+          port: {{ $grpcPort }}
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ printf "%s/management." . | replace "//" "/" | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}-grpc
+          port: {{ $grpcPort }}
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ printf "%s/server." . | replace "//" "/" | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}-grpc
+          port: {{ $grpcPort }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/pmm-ha/templates/service.yaml
+++ b/charts/pmm-ha/templates/service.yaml
@@ -26,8 +26,8 @@ spec:
     {{- include "pmm.selectorLabels" . | nindent 4 }}
 {{- if or .Values.ingress.enabled .Values.gateway.enabled }}
 ---
-# Regular ClusterIP service for ingress routing
-# Note: Both HTTP and gRPC traffic use this service when ingress is enabled
+# Regular ClusterIP service for ingress / gateway routing
+# Note: Both HTTP and gRPC traffic use this service when ingress or gateway is enabled
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/pmm-ha/templates/service.yaml
+++ b/charts/pmm-ha/templates/service.yaml
@@ -24,7 +24,7 @@ spec:
   {{- end }}
   selector:
     {{- include "pmm.selectorLabels" . | nindent 4 }}
-{{- if .Values.ingress.enabled }}
+{{- if or .Values.ingress.enabled .Values.gateway.enabled }}
 ---
 # Regular ClusterIP service for ingress routing
 # Note: Both HTTP and gRPC traffic use this service when ingress is enabled

--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -288,11 +288,11 @@ gateway:
     ## @param gateway.parentRefs[0].sectionName -- Listener section name on the Gateway (omit to match all listeners)
       sectionName: ""
 
-  ## Hostnames and path mappings
+  ## Hostnames and path lists (paths are aggregated and applied route-wide)
   hosts:
     ## @param gateway.hosts[0].host -- Hostname to match
     - host: chart-example.local
-    ## @param gateway.hosts[0].paths -- Path prefixes to route
+    ## @param gateway.hosts[0].paths -- Path prefixes to route (aggregated across hosts and applied route-wide)
       paths: []
 
   ## @param gateway.pathType -- Path match type: PathPrefix, Exact, or RegularExpression

--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -270,6 +270,34 @@ ingress:
   ##    hosts:
   ##      - chart-example.local
 
+## Gateway API configuration
+## Requires Gateway API CRDs to be installed in the cluster.
+## ref: https://gateway-api.sigs.k8s.io/
+##
+gateway:
+  ## @param gateway.enabled -- Enable Gateway API HTTPRoute resource
+  enabled: false
+  ## @param gateway.annotations -- Annotations on the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.parentRefs -- References to Gateways this HTTPRoute should attach to
+  parentRefs:
+    ## @param gateway.parentRefs[0].name -- Name of the Gateway
+    - name: ""
+    ## @param gateway.parentRefs[0].namespace -- Namespace of the Gateway (omit to use same namespace)
+      namespace: ""
+    ## @param gateway.parentRefs[0].sectionName -- Listener section name on the Gateway (omit to match all listeners)
+      sectionName: ""
+
+  ## Hostnames and path mappings
+  hosts:
+    ## @param gateway.hosts[0].host -- Hostname to match
+    - host: chart-example.local
+    ## @param gateway.hosts[0].paths -- Path prefixes to route
+      paths: []
+
+  ## @param gateway.pathType -- Path match type: PathPrefix, Exact, or RegularExpression
+  pathType: PathPrefix
+
 ## @section PMM storage configuration
 ## Claiming storage for PMM using Persistent Volume Claims (PVC)
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/

--- a/charts/pmm/Chart.yaml
+++ b/charts/pmm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pmm
 description: A Helm chart for Percona Monitoring and Management (PMM)
 type: application
-version: 1.8.1
+version: 1.8.2
 appVersion: "3.8.1"
 home: https://github.com/percona/pmm
 maintainers:

--- a/charts/pmm/README.md
+++ b/charts/pmm/README.md
@@ -89,6 +89,23 @@ It removes all of the resources associated with the last release of the chart as
 | `ingress.pathType`                | -- How ingress paths should be treated.                                                                                                        | `Prefix`              |
 | `ingress.tls`                     | -- Ingress TLS configuration                                                                                                                   | `[]`                  |
 
+### PMM Gateway API configuration
+
+| Name                                 | Description                                                                                                                                              | Value                                           |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `gateway.enabled`                    | -- Enable Gateway API HTTPRoute resource                                                                                                                | `false`                                         |
+| `gateway.annotations`                | -- Annotations on the HTTPRoute resource                                                                                                                | `{}`                                            |
+| `gateway.parentRefs`                 | -- References to Gateways this HTTPRoute should attach to                                                                                               | `[{'name':'','namespace':'','sectionName':''}]` |
+| `gateway.parentRefs[0].name`         | -- Name of the Gateway. Required when `gateway.enabled=true`                                                                                            | `""`                                            |
+| `gateway.parentRefs[0].namespace`    | -- Namespace of the Gateway (omit to use same namespace)                                                                                                | `""`                                            |
+| `gateway.parentRefs[0].sectionName`  | -- Listener section name on the Gateway (omit to match all listeners)                                                                                  | `""`                                            |
+| `gateway.hosts`                      | -- Hostnames with path lists. Paths are aggregated and applied route-wide across all listed hostnames                                                   | `[{'host':'chart-example.local','paths':[]}]`   |
+| `gateway.hosts[0].host`              | -- Hostname to match                                                                                                                                     | `chart-example.local`                           |
+| `gateway.hosts[0].paths`             | -- Path prefixes to route. Must contain at least one path when `gateway.enabled=true`                                                                  | `[]`                                            |
+| `gateway.pathType`                   | -- Path match type applied to all generated rules: `PathPrefix`, `Exact`, or `RegularExpression`                                                      | `PathPrefix`                                    |
+
+> **Gateway behavior**: when `gateway.enabled=true`, Helm fails fast unless `gateway.parentRefs[*].name` and at least one entry in `gateway.hosts[*].paths` are provided. Paths from `gateway.hosts[*].paths` are aggregated and applied route-wide to all listed hostnames. HTTP paths route to `service.name`, while gRPC-prefixed paths (`/agent.`, `/inventory.`, `/management.`, `/server.`) route to `service.name-grpc`. HTTPRoute does not configure gateway-to-backend TLS by itself; depending on your Gateway implementation, you may need `BackendTLSPolicy` (or equivalent implementation-specific settings) to enable TLS to PMM HTTPS/GRPCS backend ports.
+
 
 ### PMM storage configuration
 

--- a/charts/pmm/templates/gateway-httproute.yaml
+++ b/charts/pmm/templates/gateway-httproute.yaml
@@ -1,7 +1,10 @@
 {{- if .Values.gateway.enabled -}}
 {{- $serviceName := .Values.service.name -}}
 {{- $grpcPort := (index $.Values.service.ports 0).port -}}
-{{- $servicePort := (index $.Values.service.ports 1).port -}}
+{{- $servicePort := (index $.Values.service.ports 0).port -}}
+{{- if gt (len $.Values.service.ports) 1 -}}
+{{- $servicePort = (index $.Values.service.ports 1).port -}}
+{{- end -}}
 {{- $pathType := .Values.gateway.pathType -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -45,8 +48,7 @@ spec:
   {{- fail "gateway.hosts[*].paths must contain at least one path when gateway.enabled=true" }}
   {{- end }}
   rules:
-  {{- range .Values.gateway.hosts }}
-  {{- range .paths }}
+  {{- range $allPaths }}
     - matches:
         - path:
             type: {{ $pathType }}
@@ -83,6 +85,5 @@ spec:
       backendRefs:
         - name: {{ $serviceName }}-grpc
           port: {{ $grpcPort }}
-  {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/pmm/templates/gateway-httproute.yaml
+++ b/charts/pmm/templates/gateway-httproute.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.gateway.enabled -}}
+{{- $serviceName := .Values.service.name -}}
+{{- $grpcPort := (index $.Values.service.ports 0).port -}}
+{{- $servicePort := (index $.Values.service.ports 1).port -}}
+{{- $pathType := .Values.gateway.pathType -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "pmm.fullname" . }}
+  {{- include "pmm.includeNamespace" . | nindent 2 }}
+  labels:
+    {{- include "pmm.labels" . | nindent 4 }}
+  {{- with .Values.gateway.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  parentRefs:
+  {{- range .Values.gateway.parentRefs }}
+    - name: {{ .name | quote }}
+      {{- if .namespace }}
+      namespace: {{ .namespace | quote }}
+      {{- end }}
+      {{- if .sectionName }}
+      sectionName: {{ .sectionName | quote }}
+      {{- end }}
+  {{- end }}
+  {{- if .Values.gateway.hosts }}
+  hostnames:
+  {{- range .Values.gateway.hosts }}
+    - {{ .host | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.gateway.hosts }}
+  {{- range .paths }}
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ . | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}
+          port: {{ $servicePort }}
+    # gRPC paths — configure protocol-level gRPC handling via gateway.annotations
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ printf "%s/agent." . | replace "//" "/" | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}-grpc
+          port: {{ $grpcPort }}
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ printf "%s/inventory." . | replace "//" "/" | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}-grpc
+          port: {{ $grpcPort }}
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ printf "%s/management." . | replace "//" "/" | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}-grpc
+          port: {{ $grpcPort }}
+    - matches:
+        - path:
+            type: {{ $pathType }}
+            value: {{ printf "%s/server." . | replace "//" "/" | quote }}
+      backendRefs:
+        - name: {{ $serviceName }}-grpc
+          port: {{ $grpcPort }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/pmm/templates/gateway-httproute.yaml
+++ b/charts/pmm/templates/gateway-httproute.yaml
@@ -37,6 +37,13 @@ spec:
     - {{ .host | quote }}
   {{- end }}
   {{- end }}
+  {{- $allPaths := list -}}
+  {{- range .Values.gateway.hosts }}
+  {{- $allPaths = concat $allPaths (default (list) .paths) -}}
+  {{- end }}
+  {{- if empty $allPaths }}
+  {{- fail "gateway.hosts[*].paths must contain at least one path when gateway.enabled=true" }}
+  {{- end }}
   rules:
   {{- range .Values.gateway.hosts }}
   {{- range .paths }}

--- a/charts/pmm/templates/gateway-httproute.yaml
+++ b/charts/pmm/templates/gateway-httproute.yaml
@@ -40,6 +40,7 @@ spec:
     - {{ .host | quote }}
   {{- end }}
   {{- end }}
+  {{/* HTTPRoute hostnames are route-level, so host paths are aggregated once and applied across listed hostnames. */}}
   {{- $allPaths := list -}}
   {{- range .Values.gateway.hosts }}
   {{- $allPaths = concat $allPaths (default (list) .paths) -}}

--- a/charts/pmm/templates/gateway-httproute.yaml
+++ b/charts/pmm/templates/gateway-httproute.yaml
@@ -15,8 +15,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if empty .Values.gateway.parentRefs }}
+  {{- fail "gateway.parentRefs must be set when gateway.enabled=true" }}
+  {{- end }}
   parentRefs:
   {{- range .Values.gateway.parentRefs }}
+    {{- if empty .name }}
+    {{- fail "gateway.parentRefs[*].name must be set when gateway.enabled=true" }}
+    {{- end }}
     - name: {{ .name | quote }}
       {{- if .namespace }}
       namespace: {{ .namespace | quote }}

--- a/charts/pmm/templates/service.yaml
+++ b/charts/pmm/templates/service.yaml
@@ -22,7 +22,7 @@ spec:
   {{- end }}
   selector:
     {{- include "pmm.selectorLabels" . | nindent 4 }}
-{{- if .Values.ingress.enabled }}
+{{- if or .Values.ingress.enabled .Values.gateway.enabled }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/pmm/values.yaml
+++ b/charts/pmm/values.yaml
@@ -217,11 +217,11 @@ gateway:
     ## @param gateway.parentRefs[0].sectionName -- Listener section name on the Gateway (omit to match all listeners)
       sectionName: ""
 
-  ## Hostnames and path mappings
+  ## Hostnames and path lists (paths are aggregated and applied route-wide)
   hosts:
     ## @param gateway.hosts[0].host -- Hostname to match
     - host: chart-example.local
-    ## @param gateway.hosts[0].paths -- Path prefixes to route
+    ## @param gateway.hosts[0].paths -- Path prefixes to route (aggregated across hosts and applied route-wide)
       paths: []
 
   ## @param gateway.pathType -- Path match type: PathPrefix, Exact, or RegularExpression

--- a/charts/pmm/values.yaml
+++ b/charts/pmm/values.yaml
@@ -199,6 +199,34 @@ ingress:
   ##    hosts:
   ##      - chart-example.local
 
+## Gateway API configuration
+## Requires Gateway API CRDs to be installed in the cluster.
+## ref: https://gateway-api.sigs.k8s.io/
+##
+gateway:
+  ## @param gateway.enabled -- Enable Gateway API HTTPRoute resource
+  enabled: false
+  ## @param gateway.annotations -- Annotations on the HTTPRoute resource
+  annotations: {}
+  ## @param gateway.parentRefs -- References to Gateways this HTTPRoute should attach to
+  parentRefs:
+    ## @param gateway.parentRefs[0].name -- Name of the Gateway
+    - name: ""
+    ## @param gateway.parentRefs[0].namespace -- Namespace of the Gateway (omit to use same namespace)
+      namespace: ""
+    ## @param gateway.parentRefs[0].sectionName -- Listener section name on the Gateway (omit to match all listeners)
+      sectionName: ""
+
+  ## Hostnames and path mappings
+  hosts:
+    ## @param gateway.hosts[0].host -- Hostname to match
+    - host: chart-example.local
+    ## @param gateway.hosts[0].paths -- Path prefixes to route
+      paths: []
+
+  ## @param gateway.pathType -- Path match type: PathPrefix, Exact, or RegularExpression
+  pathType: PathPrefix
+
 ## @section PMM storage configuration
 ## Claiming storage for PMM using Persistent Volume Claims (PVC)
 ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
This pull request adds Gateway API support to both the `pmm` and `pmm-ha` Helm charts, allowing configuration of HTTPRoute resources for advanced ingress and gRPC routing via the Gateway API. It introduces new templates and values to enable, configure, and map HTTP and gRPC paths, and ensures that services are exposed correctly when either Ingress or Gateway API is enabled. Additionally, both charts receive a patch version bump.

**Gateway API integration:**

* Added `gateway-httproute.yaml` template to both `charts/pmm/templates/` and `charts/pmm-ha/templates/` for generating HTTPRoute resources when Gateway API is enabled. This template supports custom host/path routing and gRPC path handling. [[1]](diffhunk://#diff-dd8083d1fa7e6b96b630f471f1e1c57fffab4a8fb83b71decf871ccb4e3bb2faR1-R75) [[2]](diffhunk://#diff-659c5896cc92843844855c742f99b4af522a7c11436c8e7d6eb5bdc8a1d863f3R1-R74)
* Introduced a new `gateway` section in both `charts/pmm/values.yaml` and `charts/pmm-ha/values.yaml` for configuring Gateway API options such as enabling/disabling, annotations, parentRefs, hosts, paths, and pathType. [[1]](diffhunk://#diff-3c6e9afba7db8af231479cc18ca4e4769ff9611844b07b71fca6003c543e6468R202-R229) [[2]](diffhunk://#diff-65e172c3e0900890860d5767724f3f1c473c9701ca4d0d98d01a377ebf009fa1R273-R300)

**Service exposure logic:**

* Updated `service.yaml` in both charts to expose the ClusterIP service when either Ingress or Gateway API is enabled, ensuring correct routing for both HTTP and gRPC traffic. [[1]](diffhunk://#diff-88447a006e7e0946e209a71f49290a824b68bd938a07eba86beab77cb82aedf6L25-R25) [[2]](diffhunk://#diff-544313cf13d4100b0e3ce10f0d476b3d58964605271dc91489000dbe7a1fa948L27-R27)

**Version bumps:**

* Bumped `charts/pmm/Chart.yaml` version from `1.8.1` to `1.8.2`.
* Bumped `charts/pmm-ha/Chart.yaml` version from `1.5.1` to `1.5.2`.


Fixes https://github.com/percona/percona-helm-charts/issues/902