### PR TITLE
PMM-13860: Add PMM_HA_NAMESPACE to statefulset

### DIFF
--- a/charts/pmm-ha/templates/statefulset.yaml
+++ b/charts/pmm-ha/templates/statefulset.yaml
@@ -168,6 +168,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: PMM_HA_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
             {{ if .Values.secret.create }}
             # additional secrets that could be used for Grafana iDP
             - name: GF_AUTH_GENERIC_OAUTH_CLIENT_ID

--- a/charts/pmm-ha/templates/statefulset.yaml
+++ b/charts/pmm-ha/templates/statefulset.yaml
@@ -169,7 +169,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: PMM_HA_NAMESPACE
-              value: {{ .Release.Namespace | quote }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             {{ if .Values.secret.create }}
             # additional secrets that could be used for Grafana iDP
             - name: GF_AUTH_GENERIC_OAUTH_CLIENT_ID


### PR DESCRIPTION
Add PMM_HA_NAMESPACE  to statefulset, so that PMM Server pods can read it and pass it along to the UI