### PR TITLE
PMM-15309 Add read-only ClickHouse data source user

### DIFF
--- a/charts/pmm-ha/README.md
+++ b/charts/pmm-ha/README.md
@@ -388,7 +388,8 @@ including Viewers, so that account must not be the one PMM writes Query Analytic
 
 Nothing needs to be added to `pmm-secret` for this. The chart creates the ClickHouse user itself,
 through a `users.d` drop-in that grants it `SELECT` on the Query Analytics database and nothing
-else, and stores its credentials in its own secret, `<release>-pmm-clickhouse-datasource`. The
+else, and stores its credentials in its own secret, named after the chart fullname and suffixed
+`-clickhouse-datasource` — `pmm-ha-clickhouse-datasource` for the documented release name. The
 password is generated on first install and preserved across upgrades. Withholding the `SOURCES`
 privileges is what keeps table functions such as `url()` and `file()` out of reach.
 
@@ -396,7 +397,7 @@ To read the credentials, or to pin them with `clickhouse.datasource.user` and
 `clickhouse.datasource.password`:
 
 ```sh
-kubectl get secret <release>-pmm-clickhouse-datasource -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode && echo
+kubectl get secret pmm-ha-clickhouse-datasource -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode && echo
 ```
 
 #### Option 1: Create Secret with kubectl

--- a/charts/pmm-ha/README.md
+++ b/charts/pmm-ha/README.md
@@ -380,6 +380,21 @@ kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_ADMIN_PASSWORD}' | 
 
 Since `secret.create` is set to `false` by default, you need to create the `pmm-secret` manually before installing the chart. Here are examples of how to create it:
 
+#### ClickHouse data source credentials
+
+`PMM_CLICKHOUSE_DATASOURCE_USER` and `PMM_CLICKHOUSE_DATASOURCE_PASSWORD` are a **read-only**
+ClickHouse account, kept separate from `PMM_CLICKHOUSE_USER`. Grafana runs data source queries on
+behalf of every signed-in user, including Viewers, so the account behind the ClickHouse data source
+must not be the one PMM writes Query Analytics data with.
+
+The chart creates this user in the ClickHouse cluster through a `users.d` drop-in, granting it
+`SELECT` on the Query Analytics database and nothing else. Withholding the `SOURCES` privileges is
+what keeps table functions such as `url()` and `file()` out of reach.
+
+When upgrading an existing deployment with `secret.create: false`, add both keys to `pmm-secret`
+before upgrading. The chart fails with an explicit message if they are missing, rather than leaving
+the data source unable to authenticate.
+
 #### Option 1: Create Secret with kubectl
 
 ```sh
@@ -388,6 +403,8 @@ kubectl create secret generic pmm-secret \
   --from-literal=PMM_ADMIN_PASSWORD="your-secure-password" \
   --from-literal=PMM_CLICKHOUSE_USER="clickhouse_pmm" \
   --from-literal=PMM_CLICKHOUSE_PASSWORD="your-clickhouse-password" \
+  --from-literal=PMM_CLICKHOUSE_DATASOURCE_USER="clickhouse_pmm_readonly" \
+  --from-literal=PMM_CLICKHOUSE_DATASOURCE_PASSWORD="your-clickhouse-readonly-password" \
   --from-literal=VMAGENT_remoteWrite_basicAuth_username="victoriametrics_pmm" \
   --from-literal=VMAGENT_remoteWrite_basicAuth_password="your-victoriametrics-password" \
   --from-literal=PG_PASSWORD="your-pmm-postgres-password" \
@@ -410,6 +427,8 @@ stringData:
   PMM_ADMIN_PASSWORD: "your-secure-password"
   PMM_CLICKHOUSE_USER: "clickhouse_pmm"
   PMM_CLICKHOUSE_PASSWORD: "your-clickhouse-password"
+  PMM_CLICKHOUSE_DATASOURCE_USER: "clickhouse_pmm_readonly"
+  PMM_CLICKHOUSE_DATASOURCE_PASSWORD: "your-clickhouse-readonly-password"
   VMAGENT_remoteWrite_basicAuth_username: "victoriametrics_pmm"
   VMAGENT_remoteWrite_basicAuth_password: "your-victoriametrics-password"
   PG_PASSWORD: "your-pmm-postgres-password"
@@ -435,6 +454,8 @@ kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_ADMIN_PASSWORD}' | 
 # Get ClickHouse credentials
 kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_USER}' | base64 --decode && echo
 kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_PASSWORD}' | base64 --decode && echo
+kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_USER}' | base64 --decode && echo
+kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode && echo
 
 # Get VictoriaMetrics credentials
 kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.VMAGENT_remoteWrite_basicAuth_username}' | base64 --decode && echo

--- a/charts/pmm-ha/README.md
+++ b/charts/pmm-ha/README.md
@@ -382,18 +382,22 @@ Since `secret.create` is set to `false` by default, you need to create the `pmm-
 
 #### ClickHouse data source credentials
 
-`PMM_CLICKHOUSE_DATASOURCE_USER` and `PMM_CLICKHOUSE_DATASOURCE_PASSWORD` are a **read-only**
-ClickHouse account, kept separate from `PMM_CLICKHOUSE_USER`. Grafana runs data source queries on
-behalf of every signed-in user, including Viewers, so the account behind the ClickHouse data source
-must not be the one PMM writes Query Analytics data with.
+The Grafana ClickHouse data source connects as a **read-only** ClickHouse account, separate from
+`PMM_CLICKHOUSE_USER`. Grafana runs data source queries on behalf of every signed-in user,
+including Viewers, so that account must not be the one PMM writes Query Analytics data with.
 
-The chart creates this user in the ClickHouse cluster through a `users.d` drop-in, granting it
-`SELECT` on the Query Analytics database and nothing else. Withholding the `SOURCES` privileges is
-what keeps table functions such as `url()` and `file()` out of reach.
+Nothing needs to be added to `pmm-secret` for this. The chart creates the ClickHouse user itself,
+through a `users.d` drop-in that grants it `SELECT` on the Query Analytics database and nothing
+else, and stores its credentials in its own secret, `<release>-pmm-clickhouse-datasource`. The
+password is generated on first install and preserved across upgrades. Withholding the `SOURCES`
+privileges is what keeps table functions such as `url()` and `file()` out of reach.
 
-When upgrading an existing deployment with `secret.create: false`, add both keys to `pmm-secret`
-before upgrading. The chart fails with an explicit message if they are missing, rather than leaving
-the data source unable to authenticate.
+To read the credentials, or to pin them with `clickhouse.datasource.user` and
+`clickhouse.datasource.password`:
+
+```sh
+kubectl get secret <release>-pmm-clickhouse-datasource -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode && echo
+```
 
 #### Option 1: Create Secret with kubectl
 
@@ -403,8 +407,6 @@ kubectl create secret generic pmm-secret \
   --from-literal=PMM_ADMIN_PASSWORD="your-secure-password" \
   --from-literal=PMM_CLICKHOUSE_USER="clickhouse_pmm" \
   --from-literal=PMM_CLICKHOUSE_PASSWORD="your-clickhouse-password" \
-  --from-literal=PMM_CLICKHOUSE_DATASOURCE_USER="clickhouse_pmm_readonly" \
-  --from-literal=PMM_CLICKHOUSE_DATASOURCE_PASSWORD="your-clickhouse-readonly-password" \
   --from-literal=VMAGENT_remoteWrite_basicAuth_username="victoriametrics_pmm" \
   --from-literal=VMAGENT_remoteWrite_basicAuth_password="your-victoriametrics-password" \
   --from-literal=PG_PASSWORD="your-pmm-postgres-password" \
@@ -427,8 +429,6 @@ stringData:
   PMM_ADMIN_PASSWORD: "your-secure-password"
   PMM_CLICKHOUSE_USER: "clickhouse_pmm"
   PMM_CLICKHOUSE_PASSWORD: "your-clickhouse-password"
-  PMM_CLICKHOUSE_DATASOURCE_USER: "clickhouse_pmm_readonly"
-  PMM_CLICKHOUSE_DATASOURCE_PASSWORD: "your-clickhouse-readonly-password"
   VMAGENT_remoteWrite_basicAuth_username: "victoriametrics_pmm"
   VMAGENT_remoteWrite_basicAuth_password: "your-victoriametrics-password"
   PG_PASSWORD: "your-pmm-postgres-password"
@@ -454,8 +454,6 @@ kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_ADMIN_PASSWORD}' | 
 # Get ClickHouse credentials
 kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_USER}' | base64 --decode && echo
 kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_PASSWORD}' | base64 --decode && echo
-kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_USER}' | base64 --decode && echo
-kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode && echo
 
 # Get VictoriaMetrics credentials
 kubectl get secret pmm-secret -n pmm -o jsonpath='{.data.VMAGENT_remoteWrite_basicAuth_username}' | base64 --decode && echo

--- a/charts/pmm-ha/templates/_helpers.tpl
+++ b/charts/pmm-ha/templates/_helpers.tpl
@@ -232,19 +232,24 @@ when nodeExporter.mode == "openshift".
 {{- end -}}
 
 {{/*
+Name of the chart-managed secret holding the read-only ClickHouse data source credentials.
+
+Kept apart from .Values.secret.name because that secret is user-managed by default, and these
+credentials are internal: the chart creates the ClickHouse user itself, so nobody has to supply
+them.
+*/}}
+{{- define "pmm.clickhouse.datasourceSecretName" -}}
+{{- printf "%s-clickhouse-datasource" (include "pmm.fullname" .) -}}
+{{- end -}}
+
+{{/*
 Username of the read-only ClickHouse user backing the Grafana data source.
 
 Grafana runs data source queries on behalf of every signed-in user, including Viewers, so this
-must not be the user PMM writes Query Analytics data with. A username already stored in the
-secret wins, so that upgrades keep using the account that exists in ClickHouse.
+must not be the user PMM writes Query Analytics data with.
 */}}
 {{- define "pmm.clickhouse.datasourceUser" -}}
-{{- $existing := (lookup "v1" "Secret" .Release.Namespace .Values.secret.name) -}}
-{{- if and $existing (index $existing.data "PMM_CLICKHOUSE_DATASOURCE_USER") -}}
-{{- index $existing.data "PMM_CLICKHOUSE_DATASOURCE_USER" | b64dec -}}
-{{- else -}}
-{{- .Values.secret.clickhouse_datasource_user | default "clickhouse_pmm_readonly" -}}
-{{- end -}}
+{{- .Values.clickhouse.datasource.user | default "clickhouse_pmm_readonly" -}}
 {{- end -}}
 
 {{/*
@@ -253,15 +258,14 @@ Password of the read-only ClickHouse data source user.
 The secret hands the plaintext to PMM while the ClickHouse drop-in needs its SHA-256, so both
 have to agree. A generated password is therefore memoised on .Values: randAlphaNum would
 otherwise return a different value to each caller and leave Grafana unable to authenticate.
+Once generated it is read back from the chart-managed secret, so upgrades keep the same value.
 */}}
 {{- define "pmm.clickhouse.datasourcePassword" -}}
-{{- $existing := (lookup "v1" "Secret" .Release.Namespace .Values.secret.name) -}}
-{{- if and $existing (index $existing.data "PMM_CLICKHOUSE_DATASOURCE_PASSWORD") -}}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace (include "pmm.clickhouse.datasourceSecretName" .)) -}}
+{{- if .Values.clickhouse.datasource.password -}}
+{{- .Values.clickhouse.datasource.password -}}
+{{- else if and $existing (index $existing.data "PMM_CLICKHOUSE_DATASOURCE_PASSWORD") -}}
 {{- index $existing.data "PMM_CLICKHOUSE_DATASOURCE_PASSWORD" | b64dec -}}
-{{- else if .Values.secret.clickhouse_datasource_password -}}
-{{- .Values.secret.clickhouse_datasource_password -}}
-{{- else if and $existing (not .Values.secret.create) -}}
-{{- fail (printf "Secret '%s' is missing required key 'PMM_CLICKHOUSE_DATASOURCE_PASSWORD'. The Grafana ClickHouse data source now connects as a read-only user, separate from PMM_CLICKHOUSE_USER. Add PMM_CLICKHOUSE_DATASOURCE_USER and PMM_CLICKHOUSE_DATASOURCE_PASSWORD to the secret, or set secret.clickhouse_datasource_password." .Values.secret.name) -}}
 {{- else -}}
 {{- if not (hasKey .Values "generatedClickhouseDatasourcePassword") -}}
 {{- $_ := set .Values "generatedClickhouseDatasourcePassword" (randAlphaNum 32) -}}

--- a/charts/pmm-ha/templates/_helpers.tpl
+++ b/charts/pmm-ha/templates/_helpers.tpl
@@ -230,3 +230,42 @@ when nodeExporter.mode == "openshift".
       action: keep
     {{- include "pmm.nodeExporter.pmmRelabelConfigs" . | nindent 4 }}
 {{- end -}}
+
+{{/*
+Username of the read-only ClickHouse user backing the Grafana data source.
+
+Grafana runs data source queries on behalf of every signed-in user, including Viewers, so this
+must not be the user PMM writes Query Analytics data with. A username already stored in the
+secret wins, so that upgrades keep using the account that exists in ClickHouse.
+*/}}
+{{- define "pmm.clickhouse.datasourceUser" -}}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace .Values.secret.name) -}}
+{{- if and $existing (index $existing.data "PMM_CLICKHOUSE_DATASOURCE_USER") -}}
+{{- index $existing.data "PMM_CLICKHOUSE_DATASOURCE_USER" | b64dec -}}
+{{- else -}}
+{{- .Values.secret.clickhouse_datasource_user | default "clickhouse_pmm_readonly" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Password of the read-only ClickHouse data source user.
+
+The secret hands the plaintext to PMM while the ClickHouse drop-in needs its SHA-256, so both
+have to agree. A generated password is therefore memoised on .Values: randAlphaNum would
+otherwise return a different value to each caller and leave Grafana unable to authenticate.
+*/}}
+{{- define "pmm.clickhouse.datasourcePassword" -}}
+{{- $existing := (lookup "v1" "Secret" .Release.Namespace .Values.secret.name) -}}
+{{- if and $existing (index $existing.data "PMM_CLICKHOUSE_DATASOURCE_PASSWORD") -}}
+{{- index $existing.data "PMM_CLICKHOUSE_DATASOURCE_PASSWORD" | b64dec -}}
+{{- else if .Values.secret.clickhouse_datasource_password -}}
+{{- .Values.secret.clickhouse_datasource_password -}}
+{{- else if and $existing (not .Values.secret.create) -}}
+{{- fail (printf "Secret '%s' is missing required key 'PMM_CLICKHOUSE_DATASOURCE_PASSWORD'. The Grafana ClickHouse data source now connects as a read-only user, separate from PMM_CLICKHOUSE_USER. Add PMM_CLICKHOUSE_DATASOURCE_USER and PMM_CLICKHOUSE_DATASOURCE_PASSWORD to the secret, or set secret.clickhouse_datasource_password." .Values.secret.name) -}}
+{{- else -}}
+{{- if not (hasKey .Values "generatedClickhouseDatasourcePassword") -}}
+{{- $_ := set .Values "generatedClickhouseDatasourcePassword" (randAlphaNum 32) -}}
+{{- end -}}
+{{- get .Values "generatedClickhouseDatasourcePassword" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pmm-ha/templates/_helpers.tpl
+++ b/charts/pmm-ha/templates/_helpers.tpl
@@ -73,6 +73,12 @@ Pod annotation
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 helm.sh/chart: {{ include "pmm.chart" . }}
 checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+{{/*
+Roll the pods when the data source credentials change. They arrive through secretKeyRef, and
+Kubernetes does not refresh environment variables in a running pod, so without this Grafana would
+keep the old password after ClickHouse has already switched to the new one.
+*/}}
+checksum/clickhouse-datasource: {{ include (print $.Template.BasePath "/clickhouse-datasource-secret.yaml") . | sha256sum }}
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations }}
 {{- end }}
@@ -271,5 +277,18 @@ Once generated it is read back from the chart-managed secret, so upgrades keep t
 {{- $_ := set .Values "generatedClickhouseDatasourcePassword" (randAlphaNum 32) -}}
 {{- end -}}
 {{- get .Values "generatedClickhouseDatasourcePassword" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Reject a ClickHouse identifier that would not survive being written into the users.d drop-in.
+
+The data source username becomes an XML element name and the database name goes into a GRANT
+statement, so neither may start with a digit nor carry characters outside the safe set. Takes a
+dict with "name" and "value".
+*/}}
+{{- define "pmm.clickhouse.validateIdentifier" -}}
+{{- if not (regexMatch "^[A-Za-z_][A-Za-z0-9_-]*$" .value) -}}
+{{- fail (printf "%s must match ^[A-Za-z_][A-Za-z0-9_-]*$ to be usable in the ClickHouse users.d drop-in, got %q" .name .value) -}}
 {{- end -}}
 {{- end -}}

--- a/charts/pmm-ha/templates/clickhouse-cluster.yaml
+++ b/charts/pmm-ha/templates/clickhouse-cluster.yaml
@@ -5,6 +5,9 @@
 {{- else if .Values.secret.clickhouse_user }}
 {{- $clickhouseUser = .Values.secret.clickhouse_user }}
 {{- end }}
+{{- $datasourceUser := include "pmm.clickhouse.datasourceUser" . }}
+{{- $datasourcePassword := include "pmm.clickhouse.datasourcePassword" . }}
+{{- $clickhouseDatabase := .Values.pmmEnv.PMM_CLICKHOUSE_DATABASE | default "pmm" }}
 apiVersion: "clickhouse.altinity.com/v1"
 kind: ClickHouseInstallation
 metadata:
@@ -78,6 +81,56 @@ spec:
           <users>
             <default remove="1"/>
           </users>
+        </clickhouse>
+
+      # Read-only user for the Grafana ClickHouse data source.
+      #
+      # Grafana runs data source queries on behalf of every signed-in user, including Viewers, so
+      # this user must not be able to do more than read Query Analytics data. The grants section
+      # is what enforces that: it replaces ClickHouse's implicit "all privileges" with an
+      # allowlist, and withholding the SOURCES privileges keeps table functions such as url(),
+      # file(), s3() and remote() out of reach, which would otherwise allow SSRF against cloud
+      # instance metadata endpoints.
+      #
+      # Declared as a drop-in rather than through the operator's users map because that map has
+      # no way to express grants.
+      users.d/pmm-datasource-user.xml: |
+        <clickhouse>
+          <profiles>
+            <pmm_datasource>
+              <readonly>1</readonly>
+              <constraints>
+                <max_execution_time>
+                  <changeable_in_readonly/>
+                </max_execution_time>
+              </constraints>
+            </pmm_datasource>
+          </profiles>
+          <users>
+            <{{ $datasourceUser }}>
+              <password_sha256_hex>{{ $datasourcePassword | sha256sum }}</password_sha256_hex>
+              <networks>
+                {{- range .Values.clickhouse.users.networks.ip }}
+                <ip>{{ . }}</ip>
+                {{- end }}
+              </networks>
+              <profile>pmm_datasource</profile>
+              <quota>default</quota>
+              <grants>
+                <query>GRANT SELECT ON {{ $clickhouseDatabase }}.*</query>
+              </grants>
+            </{{ $datasourceUser }}>
+          </users>
+        </clickhouse>
+
+      # readonly=1 blocks every setting change, but the Grafana ClickHouse plugin sets
+      # max_execution_time on each query to enforce its timeout. Marking that one setting
+      # changeable needs this flag, without which ClickHouse rejects the constraint outright.
+      config.d/pmm-settings-constraints.xml: |
+        <clickhouse>
+          <access_control_improvements>
+            <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
+          </access_control_improvements>
         </clickhouse>
 
   templates:

--- a/charts/pmm-ha/templates/clickhouse-cluster.yaml
+++ b/charts/pmm-ha/templates/clickhouse-cluster.yaml
@@ -128,14 +128,29 @@ spec:
           </users>
         </clickhouse>
 
-      # readonly=1 blocks every setting change, but the Grafana ClickHouse plugin sets
-      # max_execution_time on each query to enforce its timeout. Marking that one setting
-      # changeable needs this flag, without which ClickHouse rejects the constraint outright.
-      config.d/pmm-settings-constraints.xml: |
+      # Server-side hardening, matching what PMM Server ships for its built-in ClickHouse.
+      #
+      # settings_constraints_replace_previous: readonly=1 blocks every setting change, but the
+      # Grafana ClickHouse plugin sets max_execution_time on each query to enforce its timeout.
+      # Marking that one setting changeable needs this flag, without which ClickHouse rejects the
+      # constraint outright.
+      #
+      # select_from_system_db_requires_grant: without it ClickHouse lets every user read the whole
+      # system database regardless of its grants, so the data source user could read system.query_log
+      # and with it the SQL text of every query any user has run. The metadata the plugin needs
+      # (system.tables, columns, databases, one) stays readable either way.
+      #
+      # remote_url_allow_hosts: an empty allowlist means no host may be reached through URL-based
+      # engines and table functions - url(), remote(), mysql() and S3 over HTTP - for every user,
+      # not just the data source one. Query Analytics does not use them: replication runs over the
+      # interserver protocol and Keeper, and schema changes go through ON CLUSTER DDL.
+      config.d/pmm-hardening.xml: |
         <clickhouse>
           <access_control_improvements>
             <settings_constraints_replace_previous>true</settings_constraints_replace_previous>
+            <select_from_system_db_requires_grant>true</select_from_system_db_requires_grant>
           </access_control_improvements>
+          <remote_url_allow_hosts></remote_url_allow_hosts>
         </clickhouse>
 
   templates:

--- a/charts/pmm-ha/templates/clickhouse-cluster.yaml
+++ b/charts/pmm-ha/templates/clickhouse-cluster.yaml
@@ -8,6 +8,11 @@
 {{- $datasourceUser := include "pmm.clickhouse.datasourceUser" . }}
 {{- $datasourcePassword := include "pmm.clickhouse.datasourcePassword" . }}
 {{- $clickhouseDatabase := .Values.pmmEnv.PMM_CLICKHOUSE_DATABASE | default "pmm" }}
+{{- include "pmm.clickhouse.validateIdentifier" (dict "name" "clickhouse.datasource.user" "value" $datasourceUser) }}
+{{- include "pmm.clickhouse.validateIdentifier" (dict "name" "pmmEnv.PMM_CLICKHOUSE_DATABASE" "value" $clickhouseDatabase) }}
+{{- if or (eq $datasourceUser $clickhouseUser) (eq $datasourceUser "clickhouse_operator") }}
+{{- fail (printf "clickhouse.datasource.user must differ from the PMM ClickHouse user and from clickhouse_operator, otherwise the drop-in merges into that account and strips its privileges, got %s" $datasourceUser) }}
+{{- end }}
 apiVersion: "clickhouse.altinity.com/v1"
 kind: ClickHouseInstallation
 metadata:
@@ -117,7 +122,7 @@ spec:
               <profile>pmm_datasource</profile>
               <quota>default</quota>
               <grants>
-                <query>GRANT SELECT ON {{ $clickhouseDatabase }}.*</query>
+                <query>GRANT SELECT ON `{{ $clickhouseDatabase }}`.*</query>
               </grants>
             </{{ $datasourceUser }}>
           </users>

--- a/charts/pmm-ha/templates/clickhouse-datasource-secret.yaml
+++ b/charts/pmm-ha/templates/clickhouse-datasource-secret.yaml
@@ -1,0 +1,21 @@
+{{/*
+Credentials of the read-only ClickHouse user backing the Grafana data source.
+
+Managed by the chart rather than kept in .Values.secret, which is user-managed by default: the
+chart creates this ClickHouse user itself, so there is nothing for an operator to supply, and an
+existing deployment needs no change to its own secret when upgrading.
+*/}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pmm.clickhouse.datasourceSecretName" . }}
+  labels:
+    {{- include "pmm.labels" . | nindent 4 }}
+  {{- with .Values.secret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+type: Opaque
+data:
+  PMM_CLICKHOUSE_DATASOURCE_USER: {{ include "pmm.clickhouse.datasourceUser" . | b64enc | quote }}
+  PMM_CLICKHOUSE_DATASOURCE_PASSWORD: {{ include "pmm.clickhouse.datasourcePassword" . | b64enc | quote }}

--- a/charts/pmm-ha/templates/secret.yaml
+++ b/charts/pmm-ha/templates/secret.yaml
@@ -28,8 +28,6 @@ data:
   PMM_ADMIN_PASSWORD: {{ get $existingData "PMM_ADMIN_PASSWORD" | default (.Values.secret.pmm_password | default (randAlphaNum 32) | b64enc) | quote }}
   PMM_CLICKHOUSE_USER: {{ get $existingData "PMM_CLICKHOUSE_USER" | default (.Values.secret.clickhouse_user | default "clickhouse_pmm" | b64enc) | quote }}
   PMM_CLICKHOUSE_PASSWORD: {{ get $existingData "PMM_CLICKHOUSE_PASSWORD" | default (.Values.secret.clickhouse_password | default (randAlphaNum 32) | b64enc) | quote }}
-  PMM_CLICKHOUSE_DATASOURCE_USER: {{ include "pmm.clickhouse.datasourceUser" . | b64enc | quote }}
-  PMM_CLICKHOUSE_DATASOURCE_PASSWORD: {{ include "pmm.clickhouse.datasourcePassword" . | b64enc | quote }}
   VMAGENT_remoteWrite_basicAuth_username: {{ get $existingData "VMAGENT_remoteWrite_basicAuth_username" | default (.Values.secret.victoriametrics_user | default "victoriametrics_pmm" | b64enc) | quote }}
   VMAGENT_remoteWrite_basicAuth_password: {{ get $existingData "VMAGENT_remoteWrite_basicAuth_password" | default (.Values.secret.victoriametrics_password | default (randAlphaNum 32) | b64enc) | quote }}
   PG_PASSWORD: {{ get $existingData "PG_PASSWORD" | default (.Values.secret.pg_password | default (randAlphaNum 32) | b64enc) | quote }}

--- a/charts/pmm-ha/templates/secret.yaml
+++ b/charts/pmm-ha/templates/secret.yaml
@@ -28,6 +28,8 @@ data:
   PMM_ADMIN_PASSWORD: {{ get $existingData "PMM_ADMIN_PASSWORD" | default (.Values.secret.pmm_password | default (randAlphaNum 32) | b64enc) | quote }}
   PMM_CLICKHOUSE_USER: {{ get $existingData "PMM_CLICKHOUSE_USER" | default (.Values.secret.clickhouse_user | default "clickhouse_pmm" | b64enc) | quote }}
   PMM_CLICKHOUSE_PASSWORD: {{ get $existingData "PMM_CLICKHOUSE_PASSWORD" | default (.Values.secret.clickhouse_password | default (randAlphaNum 32) | b64enc) | quote }}
+  PMM_CLICKHOUSE_DATASOURCE_USER: {{ include "pmm.clickhouse.datasourceUser" . | b64enc | quote }}
+  PMM_CLICKHOUSE_DATASOURCE_PASSWORD: {{ include "pmm.clickhouse.datasourcePassword" . | b64enc | quote }}
   VMAGENT_remoteWrite_basicAuth_username: {{ get $existingData "VMAGENT_remoteWrite_basicAuth_username" | default (.Values.secret.victoriametrics_user | default "victoriametrics_pmm" | b64enc) | quote }}
   VMAGENT_remoteWrite_basicAuth_password: {{ get $existingData "VMAGENT_remoteWrite_basicAuth_password" | default (.Values.secret.victoriametrics_password | default (randAlphaNum 32) | b64enc) | quote }}
   PG_PASSWORD: {{ get $existingData "PG_PASSWORD" | default (.Values.secret.pg_password | default (randAlphaNum 32) | b64enc) | quote }}

--- a/charts/pmm-ha/templates/statefulset.yaml
+++ b/charts/pmm-ha/templates/statefulset.yaml
@@ -234,12 +234,12 @@ spec:
             - name: PMM_CLICKHOUSE_DATASOURCE_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secret.name }}
+                  name: {{ include "pmm.clickhouse.datasourceSecretName" . }}
                   key: PMM_CLICKHOUSE_DATASOURCE_USER
             - name: PMM_CLICKHOUSE_DATASOURCE_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secret.name }}
+                  name: {{ include "pmm.clickhouse.datasourceSecretName" . }}
                   key: PMM_CLICKHOUSE_DATASOURCE_PASSWORD
             - name: PMM_VM_URL
               value: "http://$(VMAGENT_remoteWrite_basicAuth_username):$(VMAGENT_remoteWrite_basicAuth_password)@{{ include "pmm.fullname" . }}-vmauth.{{ .Release.Namespace }}.svc.cluster.local:8427/"

--- a/charts/pmm-ha/templates/statefulset.yaml
+++ b/charts/pmm-ha/templates/statefulset.yaml
@@ -229,6 +229,18 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.secret.name }}
                   key: PMM_CLICKHOUSE_PASSWORD
+            # Read-only credentials for the Grafana ClickHouse data source, kept apart from the
+            # privileged pair above because Grafana queries run on behalf of every signed-in user.
+            - name: PMM_CLICKHOUSE_DATASOURCE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secret.name }}
+                  key: PMM_CLICKHOUSE_DATASOURCE_USER
+            - name: PMM_CLICKHOUSE_DATASOURCE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secret.name }}
+                  key: PMM_CLICKHOUSE_DATASOURCE_PASSWORD
             - name: PMM_VM_URL
               value: "http://$(VMAGENT_remoteWrite_basicAuth_username):$(VMAGENT_remoteWrite_basicAuth_password)@{{ include "pmm.fullname" . }}-vmauth.{{ .Release.Namespace }}.svc.cluster.local:8427/"
             - name: PMM_CLICKHOUSE_ADDR

--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -408,7 +408,8 @@ clickhouse:
   ## @param clickhouse.datasource.password Password. Generated when empty, and kept across upgrades
   ##
   ## To get the credentials after install:
-  ##   kubectl get secret <release>-pmm-clickhouse-datasource -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode
+  ##   kubectl get secret pmm-ha-clickhouse-datasource -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode
+  ## The secret is named after the chart fullname, so adjust it if your release name differs.
   ##
   datasource:
     user: ""

--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -136,6 +136,29 @@ secret:
   ##
   clickhouse_password: ""
   ##
+  ## @param secret.clickhouse_datasource_user Read-only ClickHouse user for the Grafana data source. If not set, defaults to "clickhouse_pmm_readonly"
+  ## Grafana runs data source queries on behalf of every signed-in user, including Viewers, so this
+  ## must stay separate from secret.clickhouse_user, which PMM writes Query Analytics data with.
+  ## The chart creates this user in ClickHouse with SELECT on the QAN database and nothing else.
+  ##
+  ## To get username after install:
+  ##   kubectl get secret pmm-secret -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_USER}' | base64 --decode
+  ## E.g.
+  ## clickhouse_datasource_user: clickhouse_pmm_readonly
+  ##
+  clickhouse_datasource_user: ""
+  ##
+  ## @param secret.clickhouse_datasource_password Read-only ClickHouse data source password. If not set, it will be auto-generated
+  ## When secret.create: true and this is empty, a random 32-character password is generated.
+  ## If creating the secret manually (secret.create: false), this field is ignored.
+  ##
+  ## To get password after install:
+  ##   kubectl get secret pmm-secret -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode
+  ## E.g.
+  ## clickhouse_datasource_password: my_secure_password
+  ##
+  clickhouse_datasource_password: ""
+  ##
   ## @param secret.victoriametrics_user VictoriaMetrics user. If not set, defaults to "victoriametrics_pmm"
   ## When secret.create: true and this is empty, "victoriametrics_pmm" is used.
   ## If creating the secret manually (secret.create: false), this field is ignored.

--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -11,7 +11,7 @@
 ## @param image.imagePullSecrets Global Docker registry secret names as an array
 ##
 image:
-  repository: percona/pmm-server
+  repository: perconalab/pmm-server-fb
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "3.9.0"
@@ -135,29 +135,6 @@ secret:
   ## clickhouse_password: my_secure_password
   ##
   clickhouse_password: ""
-  ##
-  ## @param secret.clickhouse_datasource_user Read-only ClickHouse user for the Grafana data source. If not set, defaults to "clickhouse_pmm_readonly"
-  ## Grafana runs data source queries on behalf of every signed-in user, including Viewers, so this
-  ## must stay separate from secret.clickhouse_user, which PMM writes Query Analytics data with.
-  ## The chart creates this user in ClickHouse with SELECT on the QAN database and nothing else.
-  ##
-  ## To get username after install:
-  ##   kubectl get secret pmm-secret -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_USER}' | base64 --decode
-  ## E.g.
-  ## clickhouse_datasource_user: clickhouse_pmm_readonly
-  ##
-  clickhouse_datasource_user: ""
-  ##
-  ## @param secret.clickhouse_datasource_password Read-only ClickHouse data source password. If not set, it will be auto-generated
-  ## When secret.create: true and this is empty, a random 32-character password is generated.
-  ## If creating the secret manually (secret.create: false), this field is ignored.
-  ##
-  ## To get password after install:
-  ##   kubectl get secret pmm-secret -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode
-  ## E.g.
-  ## clickhouse_datasource_password: my_secure_password
-  ##
-  clickhouse_datasource_password: ""
   ##
   ## @param secret.victoriametrics_user VictoriaMetrics user. If not set, defaults to "victoriametrics_pmm"
   ## When secret.create: true and this is empty, "victoriametrics_pmm" is used.
@@ -421,6 +398,22 @@ clickhouse:
       memory: "8Gi"
       cpu: "4"
   
+  ## Read-only ClickHouse user backing the Grafana data source.
+  ## Grafana runs data source queries on behalf of every signed-in user, including Viewers, so this
+  ## account is kept separate from the one PMM writes Query Analytics data with. The chart creates
+  ## it in ClickHouse with SELECT on the Query Analytics database and nothing else, and stores its
+  ## credentials in a chart-managed secret, so neither field has to be set.
+  ##
+  ## @param clickhouse.datasource.user Username. Defaults to "clickhouse_pmm_readonly"
+  ## @param clickhouse.datasource.password Password. Generated when empty, and kept across upgrades
+  ##
+  ## To get the credentials after install:
+  ##   kubectl get secret <release>-pmm-clickhouse-datasource -o jsonpath='{.data.PMM_CLICKHOUSE_DATASOURCE_PASSWORD}' | base64 --decode
+  ##
+  datasource:
+    user: ""
+    password: ""
+
   cluster:
     # Cluster name restrictions: alphanumeric only, max 15 chars, no underscores
     name: pmmdb

--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -11,7 +11,7 @@
 ## @param image.imagePullSecrets Global Docker registry secret names as an array
 ##
 image:
-  repository: perconalab/pmm-server-fb
+  repository: percona/pmm-server
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "3.9.0"


### PR DESCRIPTION
## What

Gives the Grafana ClickHouse data source its own read-only ClickHouse user, separate from the account PMM writes Query Analytics data with.

Chart side of [percona/pmm#5747](https://github.com/percona/pmm/pull/5747), which lands in PMM 3.9.1. Only `pmm-ha` needs changes — the `pmm` chart has no ClickHouse configuration and keeps using the built-in server, whose defaults ship with PMM Server.

## Why

Grafana executes data source queries on behalf of every signed-in user, including Viewers. Today the data source connects as `PMM_CLICKHOUSE_USER`, which the chart creates with `access_management: "1"` and the default profile, so any Viewer can run arbitrary SQL with that account's privileges — `INSERT`, `ALTER`, `DROP`, and the `SOURCES` privileges that reach table functions such as `url()` and `file()`.

PMM 3.9.1 reads the data source credentials from `PMM_CLICKHOUSE_DATASOURCE_USER` and `PMM_CLICKHOUSE_DATASOURCE_PASSWORD`. Without this change the data source falls back to defaults that do not exist on the Altinity cluster, and every ClickHouse-backed panel stops working after upgrade.

## How

- `users.d/pmm-datasource-user.xml` drop-in creates the user with `GRANT SELECT` on the Query Analytics database and nothing else. A drop-in rather than the operator's `users:` map because that map cannot express `<grants>`, and withholding the `SOURCES` privileges is what blocks the table functions.
- Profile uses `readonly=1` with `max_execution_time` marked `changeable_in_readonly`, per the [Grafana plugin guidance](https://grafana.com/docs/plugins/grafana-clickhouse-datasource/latest/configure/#clickhouse-user-and-permissions). The plugin sets that setting on every query, and `readonly=2` is discouraged for shared instances.
- `config.d/pmm-settings-constraints.xml` enables `settings_constraints_replace_previous`, without which ClickHouse rejects `changeable_in_readonly` with `NOT_IMPLEMENTED`.
- Credentials live in a chart-managed secret, `<release>-pmm-clickhouse-datasource`, generated on first install and read back on upgrade.

## No action required on upgrade

`pmm-secret` is untouched. Since the chart creates the ClickHouse user itself, it picks the password too, so nothing has to be added to a hand-created secret and existing deployments upgrade unchanged. `clickhouse.datasource.user` and `clickhouse.datasource.password` are available for anyone who wants to pin them.

## Testing

`helm template` and `helm lint` pass, and the generated password in the secret matches the SHA-256 in the ClickHouse drop-in, verified for three configurations:

| Configuration | Result |
|---|---|
| defaults (`secret.create: false`) | password generated, hash matches |
| `secret.create: true` | password generated, hash matches |
| `clickhouse.datasource.password` pinned | override honoured, hash matches |

The password is memoised on `.Values`, since `randAlphaNum` would otherwise hand a different value to the secret and to the drop-in and leave Grafana unable to authenticate. Both embedded XML documents validate with `xmllint`.

