### PR TITLE
Split up linter checks and unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,30 +9,6 @@ on:
 
 
 jobs:
-  unit-test:
-    name: Helm Unit Tests (${{ matrix.target }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - test-pxc-operator
-          - test-pxc-db
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v5.0.0
-        with:
-          version: v3.21.0
-
-      - name: Install helm-unittest plugin
-        run: make helm-unittest
-
-      - name: Run ${{ matrix.target }}
-        run: make ${{ matrix.target }}
-
   lint-test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -1,0 +1,34 @@
+name: Helm Unit Tests
+
+on:
+  pull_request:
+    paths:
+    - 'charts/pxc-operator/**'
+    - 'charts/pxc-db/**'
+    - 'Makefile'
+    - '.github/workflows/unit-test.yaml'
+
+jobs:
+  unit-test:
+    name: Helm Unit Tests (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - test-pxc-operator
+          - test-pxc-db
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5.0.0
+        with:
+          version: v3.21.0
+
+      - name: Install helm-unittest plugin
+        run: make helm-unittest
+
+      - name: Run ${{ matrix.target }}
+        run: make ${{ matrix.target }}


### PR DESCRIPTION
The `helm-unittest` matrix (`test-pxc-operator`, `test-pxc-db`) shared `.github/workflows/test.yaml` with the `lint-test` job, so it ran on every PR that `lint-test` covers — including PMM-only changes, which have no unit-test suites and cannot be affected by them.

`paths-ignore` on the existing workflow does not solve this: it gates the whole workflow file, and `lint-test` in that same file is exactly what covers `charts/pmm`. GitHub Actions has no per-job path filter, so the matrix moves to its own workflow instead.

Changes:

* Added `.github/workflows/unit-test.yaml` with the `unit-test` matrix, triggered only by `charts/pxc-operator/**`, `charts/pxc-db/**`, `Makefile`, and the workflow file itself.
* Removed the `unit-test` job from `.github/workflows/test.yaml`; `lint-test` and its `paths-ignore` list are untouched.

This mirrors the pattern already used by `.github/workflows/pmm-ha-pr-checks.yaml`. The job `name:` is unchanged, so the checks still report as `Helm Unit Tests (test-pxc-operator)` and `Helm Unit Tests (test-pxc-db)`.

Note: adding a chart with unit-test suites now means adding a `test-<chart>` target to the `Makefile`, a matrix entry **and** a `paths:` trigger in `.github/workflows/unit-test.yaml`.

Verified on percona/percona-helm-charts#930, where both jobs ran green from the new workflow.