### PR TITLE
Add optional PDB for the psmdb-operator Deployment

### DIFF
--- a/charts/psmdb-operator/Chart.yaml
+++ b/charts/psmdb-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.23.0"
 description: A Helm chart for deploying the Percona Operator for MongoDB
 name: psmdb-operator
 home: https://docs.percona.com/percona-operator-for-mongodb/
-version: 1.23.0
+version: 1.23.1
 maintainers:
   - name: hors
     email: slava.sarzhan@percona.com

--- a/charts/psmdb-operator/README.md
+++ b/charts/psmdb-operator/README.md
@@ -85,7 +85,7 @@ The chart can be customized using the following configurable parameters:
 | `image.pullPolicy`           | PSMDB Operator Container pull policy                                                                         | `IfNotPresent`                              |
 | `imagePullSecrets`           | PSMDB Operator Pod pull secret                                                                               | `[]`                                        |
 | `replicaCount`               | PSMDB Operator Pod quantity                                                                                  | `1`                                         |
-| `podDisruptionBudget.enabled` | Create a PodDisruptionBudget for the operator Deployment. Backup schedules run in the leader process and are not Kubernetes CronJobs; a missed tick is not backfilled. Enable together with `replicaCount` >= 2 (`maxUnavailable=1` does not protect a single replica) | `false` |
+| `podDisruptionBudget.enabled` | Create a PodDisruptionBudget for the operator Deployment                                                      | `false`                                     |
 | `podDisruptionBudget.maxUnavailable` | PDB maxUnavailable                                                                                   | `1`                                         |
 | `podDisruptionBudget.minAvailable` | PDB minAvailable. Do not set together with maxUnavailable                                          | unset                                       |
 | `revisionHistoryLimit`       | Quantity of old ReplicaSets to retain for rollback purposes                                                  | `10`                                        |

--- a/charts/psmdb-operator/README.md
+++ b/charts/psmdb-operator/README.md
@@ -85,6 +85,9 @@ The chart can be customized using the following configurable parameters:
 | `image.pullPolicy`           | PSMDB Operator Container pull policy                                                                         | `IfNotPresent`                              |
 | `imagePullSecrets`           | PSMDB Operator Pod pull secret                                                                               | `[]`                                        |
 | `replicaCount`               | PSMDB Operator Pod quantity                                                                                  | `1`                                         |
+| `podDisruptionBudget.enabled` | Create a PodDisruptionBudget for the operator Deployment. Backup schedules run in the leader process and are not Kubernetes CronJobs; a missed tick is not backfilled. Enable together with `replicaCount` >= 2 (`maxUnavailable=1` does not protect a single replica) | `false` |
+| `podDisruptionBudget.maxUnavailable` | PDB maxUnavailable                                                                                   | `1`                                         |
+| `podDisruptionBudget.minAvailable` | PDB minAvailable. Do not set together with maxUnavailable                                          | unset                                       |
 | `revisionHistoryLimit`       | Quantity of old ReplicaSets to retain for rollback purposes                                                  | `10`                                        |
 | `tolerations`                | List of node taints to tolerate                                                                              | `[]`                                        |
 | `annotations`                | PSMDB Operator Deployment annotations                                                                        | `{}`                                        |

--- a/charts/psmdb-operator/templates/pdb.yaml
+++ b/charts/psmdb-operator/templates/pdb.yaml
@@ -7,11 +7,10 @@ metadata:
   labels:
     {{- include "psmdb-operator.labels" . | nindent 4 }}
 spec:
-  {{- with .Values.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ . }}
-  {{- end }}
-  {{- with .Values.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/psmdb-operator/templates/pdb.yaml
+++ b/charts/psmdb-operator/templates/pdb.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "psmdb-operator.fullname" . }}
+  namespace: {{ include "psmdb-operator.namespace" . }}
+  labels:
+    {{- include "psmdb-operator.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "psmdb-operator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/psmdb-operator/values.yaml
+++ b/charts/psmdb-operator/values.yaml
@@ -120,3 +120,11 @@ logLevel: "INFO"
 # maxConcurrentReconciles controls the number of concurrent workers
 # that can reconcile resources in Percona Server for MongoDB clusters in parallel.
 maxConcurrentReconciles: "1"
+
+# Backup schedules run in the operator leader process (robfig/cron), not as
+# Kubernetes CronJobs. A missed tick is not backfilled. replicaCount=1 plus
+# this PDB with maxUnavailable=1 still allows evicting the only pod; enable
+# the PDB together with replicaCount >= 2.
+podDisruptionBudget:
+  enabled: false
+  maxUnavailable: 1

--- a/charts/psmdb-operator/values.yaml
+++ b/charts/psmdb-operator/values.yaml
@@ -121,10 +121,6 @@ logLevel: "INFO"
 # that can reconcile resources in Percona Server for MongoDB clusters in parallel.
 maxConcurrentReconciles: "1"
 
-# Backup schedules run in the operator leader process (robfig/cron), not as
-# Kubernetes CronJobs. A missed tick is not backfilled. replicaCount=1 plus
-# this PDB with maxUnavailable=1 still allows evicting the only pod; enable
-# the PDB together with replicaCount >= 2.
 podDisruptionBudget:
   enabled: false
   maxUnavailable: 1


### PR DESCRIPTION
The operator chart has no PodDisruptionBudget. Scheduled backups run in the leader process, not as CronJobs, so evicting the only replica at the scheduled time skips that backup.

Adds `podDisruptionBudget` (default disabled). Enable with `replicaCount` >= 2. Chart version 1.23.1.

Fixes https://github.com/percona/percona-helm-charts/issues/942

Related: https://github.com/percona/percona-server-mongodb-operator/issues/2526
