### PR TITLE
feat(psmdb-db): add sidecars support for hidden and nonvoting replset

### DIFF
--- a/charts/psmdb-db/Chart.yaml
+++ b/charts/psmdb-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.23.0"
 description: A Helm chart for installing Percona Server MongoDB Cluster Databases using the PSMDB Operator.
 name: psmdb-db
 home: https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html
-version: 1.23.0
+version: 1.23.2
 maintainers:
   - name: hors
     email: slava.sarzhan@percona.com

--- a/charts/psmdb-db/templates/cluster.yaml
+++ b/charts/psmdb-db/templates/cluster.yaml
@@ -450,6 +450,18 @@ spec:
         emptyDir: {}
         {{- end }}
       {{- end }}
+      {{- if $replset.hidden.sidecars }}
+      sidecars:
+{{ $replset.hidden.sidecars | toYaml | indent 8 }}
+      {{- end }}
+      {{- if $replset.hidden.sidecarVolumes }}
+      sidecarVolumes:
+{{ $replset.hidden.sidecarVolumes | toYaml | indent 8 }}
+      {{- end }}
+      {{- if $replset.hidden.sidecarPVCs }}
+      sidecarPVCs:
+{{ $replset.hidden.sidecarPVCs | toYaml | indent 8 }}
+      {{- end }}
     {{- end }}
     {{- if $replset.nonvoting }}
     nonvoting:
@@ -542,6 +554,18 @@ spec:
         {{- else }}
         emptyDir: {}
         {{- end }}
+      {{- end }}
+      {{- if $replset.nonvoting.sidecars }}
+      sidecars:
+{{ $replset.nonvoting.sidecars | toYaml | indent 8 }}
+      {{- end }}
+      {{- if $replset.nonvoting.sidecarVolumes }}
+      sidecarVolumes:
+{{ $replset.nonvoting.sidecarVolumes | toYaml | indent 8 }}
+      {{- end }}
+      {{- if $replset.nonvoting.sidecarPVCs }}
+      sidecarPVCs:
+{{ $replset.nonvoting.sidecarPVCs | toYaml | indent 8 }}
       {{- end }}
     {{- end }}
     {{- if $replset.arbiter }}

--- a/charts/psmdb-db/values.yaml
+++ b/charts/psmdb-db/values.yaml
@@ -438,6 +438,20 @@ replsets:
           resources:
             requests:
               storage: 3Gi
+#      sidecars:
+#      - image: busybox
+#        command: ["/bin/sh"]
+#        args: ["-c", "while true; do echo echo $(date -u) 'test' >> /dev/null; sleep 5;done"]
+#        name: hidden-sidecar-1
+#      sidecarVolumes:
+#      - name: sidecar-secret
+#        secret:
+#          secretName: mysecret
+#      sidecarPVCs:
+#      - apiVersion: v1
+#        kind: PersistentVolumeClaim
+#        metadata:
+#          name: sidecar-volume-claim
 
     nonvoting:
       enabled: false
@@ -510,6 +524,20 @@ replsets:
           resources:
             requests:
               storage: 3Gi
+      # sidecars:
+      # - image: busybox
+      #   command: ["/bin/sh"]
+      #   args: ["-c", "while true; do echo echo $(date -u) 'test' >> /dev/null; sleep 5;done"]
+      #   name: nonvoting-sidecar-1
+      # sidecarVolumes:
+      # - name: sidecar-secret
+      #   secret:
+      #     secretName: mysecret
+      # sidecarPVCs:
+      # - apiVersion: v1
+      #   kind: PersistentVolumeClaim
+      #   metadata:
+      #     name: sidecar-volume-claim
     arbiter:
       enabled: false
       size: 1


### PR DESCRIPTION
The `hidden` and `nonvoting` replset node types were missing `sidecars` support in the cluster.yaml template,
while regular replset nodes, `configsvrReplSet`, and mongos all supported it.

This adds the missing `{{- if $replset.hidden.sidecars }}` and `{{- if $replset.nonvoting.sidecars }}`
blocks following the same pattern used for other node types,
and adds corresponding commented-out examples to `values.yaml`.