### PR TITLE
PMM-15441 Fit the pmm-ha CI install back onto the Kind node

### DIFF
--- a/charts/pmm-ha/ci/ci-values.yaml
+++ b/charts/pmm-ha/ci/ci-values.yaml
@@ -12,6 +12,18 @@ pmmResources:
     memory: "1Gi"
     cpu: "500m"
 
+# One Client is enough to exercise the StatefulSet. The chart default of 3 does not
+# fit next to 3 PMM replicas on the single-node Kind cluster.
+pmmClient:
+  replicas: 1
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "50m"
+    limits:
+      memory: "512Mi"
+      cpu: "200m"
+
 clickhouse:
   cluster:
     shards: 1
@@ -24,7 +36,9 @@ clickhouse:
       memory: "1Gi"
       cpu: "500m"
   keeper:
-    replicas: 1
+    # The chart reads replicasCount (templates/clickhouse-keeper.yaml); a plain
+    # "replicas" key here is silently ignored, leaving CI on the default of 3.
+    replicasCount: 1
     resources:
       requests:
         memory: "512Mi"


### PR DESCRIPTION
Jira: https://perconadev.atlassian.net/browse/PMM-15441

## Problem

Every PR against `PMM-HA-GA` is red on `PMM-HA PR checks / lint-test`. Lint itself passes (`1 chart(s) linted, 0 chart(s) failed`) — the failing step is `Run chart-testing (install pmm-ha)`:

```
Error: INSTALLATION FAILED: context deadline exceeded
Warning  FailedScheduling  pod/pmm-ha-<release>-2
  0/1 nodes are available: 1 Insufficient cpu.
```

The Kind cluster is a single ~4 vCPU node. The PMM StatefulSet is ordered, so replica `-2` is only created ~6 minutes in, by which point every other pod has claimed the node's CPU. It stays `Pending` and Helm's `--timeout 600s` expires.

## Cause

`0766844` (PMM-14665, #913) added `charts/pmm-ha/templates/pmm-client-statefulset.yaml` with `pmmClient.replicas: 3` at `cpu: 100m` each, and no matching override in `charts/pmm-ha/ci/ci-values.yaml` — +300m of requests on a node with no headroom. #913's own branch was already failing with this exact error before it merged (runs on 2026-08-30 and 2026-09-03).

Contributing: `ci/ci-values.yaml` sets `clickhouse.keeper.replicas: 1`, but the chart reads `clickhouse.keeper.replicasCount` (`templates/clickhouse-keeper.yaml#L10`). That override has been a silent no-op since `a116efb` (2026-01-09), so CI has been running 3 Keepers instead of 1 — another +200m.

Base branch was green at `c94c0ef` (06:49 UTC, 2026-09-03) and red from `0766844` (07:27 UTC) onward.

## Fix

CI values only — chart defaults are unchanged. The Client pod's init container has hardcoded 50m requests, so a pod's effective request is `max(init, containers)`:

| | Before | After | Δ |
|---|---|---|---|
| pmm-client | 3 × max(100m, 50m) = 300m | 1 × max(50m, 50m) = 50m | −250m |
| clickhouse-keeper | 3 × 100m = 300m | 1 × 100m = 100m | −200m |
| **Total freed** | | | **−450m** |

The stuck replica needs 200m.

Not the fix: raising the `ct` timeout (the pod is `Pending`, it would never schedule), or a multi-node Kind cluster (each Kind node reports the host's full 4 vCPU, so that would over-subscribe and trade a hard failure for a starvation flake).

## Verification

`yq` confirms every override now resolves to a key the chart actually reads — `pmmClient.replicas`, `pmmClient.resources` (`pmm-client-statefulset.yaml#L13,L107`) and `clickhouse.keeper.replicasCount` — and that the dead `clickhouse.keeper.replicas` key is gone. The real check is this PR's own `lint-test` run going green.

Unblocks #865, #868, #919, #935, #936, #937, #938, #940, #941, #944.
