### PR TITLE
[psmdb-db] render metadata.finalizers only when the list is non-empty

### DIFF
--- a/charts/psmdb-db/Chart.yaml
+++ b/charts/psmdb-db/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.23.0"
 description: A Helm chart for installing Percona Server MongoDB Cluster Databases using the PSMDB Operator.
 name: psmdb-db
 home: https://www.percona.com/doc/kubernetes-operator-for-psmongodb/index.html
-version: 1.23.0
+version: 1.23.1
 maintainers:
   - name: hors
     email: slava.sarzhan@percona.com

--- a/charts/psmdb-db/templates/cluster.yaml
+++ b/charts/psmdb-db/templates/cluster.yaml
@@ -9,8 +9,10 @@ metadata:
   namespace: {{ include "psmdb-database.namespace" . }}
   labels:
 {{ include "psmdb-database.labels" . | indent 4 }}
+  {{- if .Values.finalizers }}
   finalizers:
 {{ .Values.finalizers | toYaml | indent 4 }}
+  {{- end }}
 spec:
   crVersion: {{ .Values.crVersion }}
   pause: {{ .Values.pause }}


### PR DESCRIPTION
When `finalizers` is set to an empty list, the chart renders `metadata.finalizers: []` on the PerconaServerMongoDB resource. The API server drops the empty list, so the live object never matches the rendered manifest and GitOps tools such as ArgoCD report the resource as permanently OutOfSync.

This change wraps the block in `{{- if .Values.finalizers }}`, the same way `pg-db` already does, so the key is only rendered when there is something in it. The default value is unchanged and still renders `percona.com/delete-psmdb-pods-in-order`.

Testing:
- `helm template` with default values produces byte-identical output to `main`.
- `helm template --set-json 'finalizers=[]'` (and `null`) no longer emits `metadata.finalizers`. Custom lists still render.
- `helm lint charts/psmdb-db` passes.
- Verified with Helm 3.16.3, 3.17.1, 3.19.2 and 4.2.4.