### PR TITLE
PMM-15426 Make the pmm-ha chart installable on OpenShift

### DIFF
--- a/charts/pmm-ha/Chart.yaml
+++ b/charts/pmm-ha/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pmm-ha
 description: A Helm chart for Percona Monitoring and Management (PMM)
 type: application
-version: 1.6.2
+version: 1.6.3
 appVersion: "3.9.1"
 home: https://github.com/percona/pmm
 maintainers:

--- a/charts/pmm-ha/README.md
+++ b/charts/pmm-ha/README.md
@@ -387,6 +387,7 @@ To create additional service tokens manually, see the [PMM documentation on serv
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------- |
 | `haproxy.service.type`        | Service type for HAProxy: ClusterIP (internal), LoadBalancer (external via LB), or NodePort (external via node) | `ClusterIP` |
 | `haproxy.service.annotations` | Service annotations (add cloud-specific annotations as needed)                                                   | `{}`        |
+| `haproxy.containerPorts.https` | Port HAProxy binds for PMM traffic; the Service publishes the same port. Must be above 1024 on OpenShift        | `443`       |
 
 
 ### PMM storage configuration
@@ -410,7 +411,8 @@ To create additional service tokens manually, see the [PMM documentation on serv
 | `serviceAccount.annotations` | Annotations for service account. Evaluated as a template. Only used if `create` is `true`.                          | `{}`                  |
 | `serviceAccount.name`        | Name of the service account to use. If not set and create is true, a name is generated using the fullname template. | `pmm-service-account` |
 | `podAnnotations`             | Pod annotations                                                                                                     | `{}`                  |
-| `podSecurityContext`         | Configure Pods Security Context                                                                                     | `{}`                  |
+| `podSecurityContext`         | Configure Pods Security Context. Ignored when `openshift` is `true`                                                 | `{runAsUser: 1000, fsGroup: 1000}` |
+| `openshift`                  | Set to `true` on OpenShift so the chart emits no pod securityContext and the cluster assigns the uid/fsGroup        | `false`               |
 | `securityContext`            | Configure Container Security Context                                                                                | `{}`                  |
 | `nodeSelector`               | Node labels for pod assignment                                                                                      | `{}`                  |
 | `tolerations`                | Tolerations for pod assignment                                                                                      | `[]`                  |
@@ -655,6 +657,21 @@ victoriaMetrics:
     extraArgs:
       maxLabelsPerTimeseries: "60"
 ```
+
+### Installing on OpenShift
+
+OpenShift's `restricted-v2` SCC gives every namespace its own uid and supplemental-group ranges
+and rejects any pod asking for values outside them, and it runs containers without
+`NET_BIND_SERVICE`. Install with the bundled overlay, which covers all of it:
+
+```bash
+helm install pmm-ha percona/pmm-ha -n pmm -f examples/values-openshift.yaml
+```
+
+It sets `openshift: true` (PMM Server and PMM Client let the cluster assign uid and fsGroup),
+disables the bundled node-exporter in favour of OpenShift's, turns off the kube-state-metrics
+securityContext, and moves the HAProxy port to 8443. Publish 443 externally with a Route or
+Ingress pointing at the HAProxy Service.
 
 ### Using OpenShift's node exporter
 

--- a/charts/pmm-ha/examples/values-openshift.yaml
+++ b/charts/pmm-ha/examples/values-openshift.yaml
@@ -1,0 +1,33 @@
+## OpenShift overlay for the pmm-ha chart.
+##
+##   helm install pmm-ha percona/pmm-ha -n <namespace> -f examples/values-openshift.yaml
+##
+## OpenShift's `restricted-v2` SCC gives every namespace its own uid range and supplemental-group
+## range and rejects any pod requesting values outside them. Each setting below clears one such
+## rejection; without them the StatefulSets and Deployments are admitted-then-refused and Helm
+## still reports STATUS: deployed while no pods exist.
+
+## PMM Server and PMM Client: emit no pod securityContext, so OpenShift assigns uid and fsGroup.
+openshift: true
+
+## The bundled kube-state-metrics pins uid/gid/fsGroup 65534, which is outside the namespace range.
+kube-state-metrics:
+  securityContext:
+    enabled: false
+
+## The bundled node-exporter needs hostNetwork, hostPID, hostPath volumes and host port 9100 -
+## none of which restricted-v2 permits. OpenShift's platform monitoring already runs a
+## node-exporter, so scrape that one instead.
+prometheus-node-exporter:
+  enabled: false
+nodeExporter:
+  mode: openshift
+
+## HAProxy terminates TLS on 443. restricted-v2 runs the container as a non-root uid with all
+## capabilities dropped and allowPrivilegeEscalation=false, so it cannot bind a port below 1024
+## (`cannot bind socket (Permission denied) for [0.0.0.0:443]`). Move the container port above
+## 1024. The HAProxy Service publishes this same port, so expose 443 externally through an
+## OpenShift Route or an Ingress pointing at the Service.
+haproxy:
+  containerPorts:
+    https: 8443

--- a/charts/pmm-ha/templates/_helpers.tpl
+++ b/charts/pmm-ha/templates/_helpers.tpl
@@ -203,7 +203,8 @@ stays valid across failovers.
 */}}
 {{- define "pmm.client.serverAddress" -}}
 {{- $haproxy := .Values.haproxy.fullnameOverride | default (printf "%s-haproxy" (include "pmm.fullname" .)) -}}
-{{- printf "%s.%s.svc.cluster.local:443" $haproxy .Release.Namespace -}}
+{{- $port := (.Values.haproxy.containerPorts).https | default 443 -}}
+{{- printf "%s.%s.svc.cluster.local:%v" $haproxy .Release.Namespace $port -}}
 {{- end -}}
 
 {{/*
@@ -404,4 +405,34 @@ dict with "name" and "value".
 {{- if not (regexMatch "^[A-Za-z_][A-Za-z0-9_-]*$" .value) -}}
 {{- fail (printf "%s must match ^[A-Za-z_][A-Za-z0-9_-]*$ to be usable in the ClickHouse users.d drop-in, got %q" .name .value) -}}
 {{- end -}}
+{{- end -}}
+
+{{/*
+Pod security context for the PMM Server StatefulSet.
+
+On OpenShift the namespace owns the identity: `restricted-v2` requires runAsUser to be inside
+the namespace's assigned uid-range and fsGroup inside its supplemental-group range, and rejects
+the pod outright otherwise. Emitting no securityContext at all lets OpenShift assign both.
+
+On plain Kubernetes fsGroup is load-bearing - it is what makes the PVC group-writable for the
+image's uid - so it must stay. runAsUser is not: the PMM Server image already declares
+`USER 1000`, and its entrypoint supports an arbitrary assigned uid via the NSS wrapper.
+*/}}
+{{- define "pmm.podSecurityContext" -}}
+{{- if not .Values.openshift }}
+securityContext:
+  {{- toYaml .Values.podSecurityContext | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Pod security context for the PMM Client StatefulSet. Same reasoning as above; the client image
+runs as uid 1002 rather than 1000.
+*/}}
+{{- define "pmm.client.podSecurityContext" -}}
+{{- if not .Values.openshift }}
+securityContext:
+  # The PMM Client image runs as this user, which has to own the volume to write to it.
+  fsGroup: {{ .Values.pmmClient.fsGroup }}
+{{- end }}
 {{- end -}}

--- a/charts/pmm-ha/templates/haproxy-configmap.yaml
+++ b/charts/pmm-ha/templates/haproxy-configmap.yaml
@@ -16,7 +16,11 @@ data:
         daemon
     
     resolvers k8s
-        nameserver dns1 kube-dns.kube-system.svc.cluster.local:53
+        # Read the cluster DNS server from the pod's own /etc/resolv.conf rather than naming
+        # a service. The vanilla-Kubernetes name kube-dns.kube-system does not exist on
+        # OpenShift (it is dns-default.openshift-dns), and HAProxy rejects an unresolvable
+        # nameserver at config-parse time, so hardcoding either name breaks the other platform.
+        parse-resolv-conf
         resolve_retries 5
         timeout resolve 2s
         timeout retry   1s
@@ -49,7 +53,12 @@ data:
     {{- end }}
     
     frontend https_front
-        bind *:443 ssl crt /etc/haproxy/certs/pmm.pem
+        # Bind port follows haproxy.containerPorts.https so it can be moved above 1024.
+        # OpenShift's restricted-v2 runs the container as a non-root uid with all
+        # capabilities dropped and allowPrivilegeEscalation=false, so NET_BIND_SERVICE is
+        # unavailable and binding 443 fails with EACCES. The Service port follows the same
+        # value, so expose 443 externally through an Ingress or an OpenShift Route.
+        bind *:{{ (.Values.haproxy.containerPorts).https | default 443 }} ssl crt /etc/haproxy/certs/pmm.pem
         default_backend https_back
 
     backend https_back

--- a/charts/pmm-ha/templates/pg-pmm-token-job.yaml
+++ b/charts/pmm-ha/templates/pg-pmm-token-job.yaml
@@ -61,7 +61,7 @@ spec:
         - name: PMM_SERVICE_NAME
           value: "pmm-ha-haproxy"
         - name: PMM_PORT
-          value: "443"
+          value: "{{ (.Values.haproxy.containerPorts).https | default 443 }}"
         - name: SECRET_NAME
           value: "{{ index .Values "pg-db" "pmm" "secret" | default "pg-pmm-secret" }}"
         - name: SERVICE_ACCOUNT_NAME

--- a/charts/pmm-ha/templates/pmm-client-statefulset.yaml
+++ b/charts/pmm-ha/templates/pmm-client-statefulset.yaml
@@ -25,9 +25,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        # The PMM Client image runs as this user, which has to own the volume to write to it.
-        fsGroup: 1002
+      {{- include "pmm.client.podSecurityContext" . | nindent 6 }}
       {{- with .Values.pmmClient.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/pmm-ha/templates/statefulset.yaml
+++ b/charts/pmm-ha/templates/statefulset.yaml
@@ -27,8 +27,7 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "pmm.serviceAccountName" . }}
       {{- end }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- include "pmm.podSecurityContext" . | nindent 6 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/pmm-ha/values.yaml
+++ b/charts/pmm-ha/values.yaml
@@ -147,6 +147,11 @@ pmmClient:
   ## PMM Server Nodes are not offered for that.
   ##
   replicas: 3
+  ## @param pmmClient.fsGroup Group that owns the PMM Client data volume
+  ## The PMM Client image runs as this user, which has to own the volume to write to it.
+  ## Ignored when `openshift: true` - OpenShift assigns the fsGroup itself.
+  ##
+  fsGroup: 1002
   ## @param pmmClient.image.repository PMM Client image repository
   ## @param pmmClient.image.pullPolicy PMM Client image pull policy
   ## @param pmmClient.image.tag PMM Client image tag, defaults to the chart appVersion
@@ -430,6 +435,17 @@ podSecurityContext:
   runAsUser: 1000
   fsGroup: 1000
 
+## @param openshift Set to true when installing on OpenShift
+## OpenShift's `restricted-v2` SCC assigns every namespace its own uid and supplemental-group
+## ranges and rejects any pod that asks for values outside them, so the `podSecurityContext`
+## above (and `pmmClient.fsGroup`) must not be set there. With this true the chart
+## emits no pod securityContext and lets OpenShift assign the identity.
+##
+## See examples/values-openshift.yaml for the full OpenShift overlay - the bundled
+## kube-state-metrics and prometheus-node-exporter need their own settings.
+##
+openshift: false
+
 ## @param securityContext Configure Container Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ## securityContext.capabilities The capabilities to add/drop when running containers
@@ -597,6 +613,14 @@ haproxy:
   # Number of HAProxy replicas
   replicaCount: 3
 
+  ## @param haproxy.containerPorts.https Port HAProxy binds for PMM traffic
+  ## The Service publishes this same port. Keep 443 on plain Kubernetes; on OpenShift it
+  ## must be above 1024, because restricted-v2 runs the container as a non-root uid with
+  ## all capabilities dropped and so without NET_BIND_SERVICE.
+  ##
+  containerPorts:
+    https: 443
+
   ## @param haproxy.resources Resource requests and limits for the HAProxy container
   ## Every client remote_write, QAN payload and UI request crosses HAProxy, and it
   ## terminates TLS for all of them. The upstream subchart ships a request but no
@@ -634,7 +658,7 @@ haproxy:
   # so scaling up/down replicas does NOT require HAProxy restart.
   # Increment config-version only for other ConfigMap changes that require restart.
   podAnnotations:
-    pmm.percona.com/config-version: "4"
+    pmm.percona.com/config-version: "5"
 
   # HAProxy pod spread across nodes.
   #


### PR DESCRIPTION
## Problem

On OpenShift with `restricted-v2`, `helm install charts/pmm-ha` reports `STATUS: deployed` while four workloads are rejected at admission and produce **zero pods**, and HAProxy crash-loops for two further reasons.

Verified live on ROSA HCP, OpenShift 4.21.30, from `PMM-HA-GA` @ 924116e.

| # | Workload | Cause |
|---|---|---|
| 1 | PMM Server StatefulSet | `podSecurityContext` `runAsUser: 1000` / `fsGroup: 1000` — outside the namespace's assigned ranges |
| 2 | PMM Client StatefulSet | hardcoded `fsGroup: 1002`, no values knob, so no user-side workaround existed |
| 3 | kube-state-metrics | subchart pins uid/gid/fsGroup `65534` |
| 4 | prometheus-node-exporter | `hostNetwork`, `hostPID`, hostPath volumes, host port 9100 |
| 5 | HAProxy | resolver named `kube-dns.kube-system`, which does not exist on OpenShift (`dns-default.openshift-dns`); HAProxy rejects an unresolvable nameserver at **config-parse time** |
| 6 | HAProxy | bound `*:443` while `restricted-v2` drops `NET_BIND_SERVICE`: `cannot bind socket (Permission denied) for [0.0.0.0:443]` |

HAProxy is the only ingress to PMM, so 5 and 6 keep PMM unreachable even once the SCC issues are fixed.

ClickHouse, VictoriaMetrics, PostgreSQL and the three operators are **not** affected — they admit cleanly under `restricted-v2`.

## Changes

- New top-level `openshift` value gating both pod securityContexts, plus a `pmmClient.fsGroup` knob. `runAsUser` was never load-bearing — the PMM Server image already declares `USER 1000` and its entrypoint handles an arbitrary assigned uid via the NSS wrapper. `fsGroup` is the part that matters, and OpenShift assigns one when the chart asks for none.
- `haproxy.containerPorts.https` now drives the HAProxy bind and every internal reference to it (`pmm.client.serverAddress`, `pg-pmm-token-job`'s `PMM_PORT`), since the subchart derives the Service port from the same value.
- HAProxy resolver uses `parse-resolv-conf`, so one line works on both platforms.
- New `examples/values-openshift.yaml` covering all six.
- README: an **Installing on OpenShift** section, the two new parameters, and a correction — `podSecurityContext`'s default was documented as `{}` while the chart ships `runAsUser: 1000, fsGroup: 1000`.

## Verification

**No regression on plain Kubernetes** — with default values every workload's pod `securityContext` renders byte-identical to before, and HAProxy still binds and publishes 443. (This held only after review: the first version of the helper emitted a whitespace-only line ahead of `securityContext:`. Fixed, and a CI render check now pins it.)

**The bundled PostgreSQL reaches PMM** — verified on plain Kubernetes with `haproxy.containerPorts.https: 8443`. With the bare `pg-db.pmm.serverHost` the sidecar looped on `dial tcp …:443: i/o timeout` while the pod stayed 5/5 Running and the inventory stayed empty; with the port spelled out it registers and `postgres_exporter` runs.

**On OpenShift**, with `-f examples/values-openshift.yaml`, the full stack reaches green: PMM Server 3/3, PMM Client 3/3, HAProxy 3/3, ClickHouse 3+3, VictoriaMetrics all up, PostgreSQL 3 + pgbouncer, kube-state-metrics 1/1, `pg-pmm-secret` created. PMM Server runs under the assigned identity with a writable volume:

```
uid=1000860000 gid=0(root) groups=0(root),1000860000
drwxrwsr-x. 14 root 1000860000 /srv     → writable
```

Full reproduce/verify commands are in the ticket.

## Not in this PR

Three bugs surfaced during verification that are **not** OpenShift-specific and need their own tickets:

- `pg-pmm-token-job.yaml` is a plain Job with a fixed name and no Helm hook, so any values change touching its pod spec fails `helm upgrade` with `spec.template: field is immutable`.
- A `%` in any password breaks supervisord — `!` URL-encodes to `%21`, ConfigParser reads `%` as a format char and refuses `vmalert.ini`, so vmalert/grafana/qan-api2/vmproxy never start and readyz stays 504.
- `PMM_ADMIN_PASSWORD` is never applied; pmm-init's only password task is skipped for non-AMI, so the admin password stays `admin` and both `pg-pmm-token-job` and `pmm-client-register` get 401.

https://perconadev.atlassian.net/browse/PMM-15426
