### PR TITLE
K8SPXC-1968 Add missing certificates/status in pxc-operator rbac

### DIFF
--- a/charts/pxc-operator/Chart.yaml
+++ b/charts/pxc-operator/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.20.0
 description: A Helm chart for deploying the Percona Operator for MySQL (based on Percona XtraDB Cluster)
 name: pxc-operator
 home: https://docs.percona.com/percona-operator-for-mysql/pxc/
-version: 1.20.0
+version: 1.20.1
 maintainers:
   - name: nmarukovich
     email: natalia.marukovich@percona.com

--- a/charts/pxc-operator/templates/role.yaml
+++ b/charts/pxc-operator/templates/role.yaml
@@ -131,6 +131,7 @@ rules:
   resources:
   - issuers
   - certificates
+  - certificates/status
   verbs:
   - get
   - list

--- a/charts/pxc-operator/tests/rbac_test.yaml
+++ b/charts/pxc-operator/tests/rbac_test.yaml
@@ -31,6 +31,30 @@ tests:
         template: templates/role-binding.yaml
         documentIndex: 1
 
+  - it: grants certificates/status for cert-manager CA rotation
+    templates:
+      - templates/role.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - certmanager.k8s.io
+              - cert-manager.io
+            resources:
+              - issuers
+              - certificates
+              - certificates/status
+            verbs:
+              - get
+              - list
+              - watch
+              - create
+              - update
+              - patch
+              - delete
+              - deletecollection
+
   - it: renders cluster-wide RBAC when watching all namespaces
     templates:
       - templates/role.yaml


### PR DESCRIPTION
This PR adds the `certificates/status` resource in rbac template that pxc-operator chart was missing.