### PR TITLE
PMM-15501 Let secret.create install the chart from scratch

### DIFF
--- a/charts/pmm-ha/templates/_helpers.tpl
+++ b/charts/pmm-ha/templates/_helpers.tpl
@@ -405,3 +405,40 @@ dict with "name" and "value".
 {{- fail (printf "%s must match ^[A-Za-z_][A-Za-z0-9_-]*$ to be usable in the ClickHouse users.d drop-in, got %q" .name .value) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve one key of the PMM secret to its base64 value, for the keys that more than one template
+needs to agree on.
+
+secret.yaml generates GF_PASSWORD and PG_PASSWORD, and pg-user-credentials-secrets.yaml has to
+write those same two passwords into the per-user credentials secrets the PostgreSQL operator
+reads. Under secret.create the secret does not exist yet at render time - Helm renders every
+template before it applies the pre-install hook that creates it - so the second template cannot
+read the value back and has to derive it the same way. Deriving it with a second randAlphaNum
+would hand Grafana a password PostgreSQL never got, so the generated value is cached on .Values
+and every caller gets the same one, the way pmm.clickhouse.datasourcePassword already does.
+
+Precedence: the key already in the secret (upgrades keep their password), then the explicit
+value from values.yaml, then a generated one. Takes a dict with "ctx" (the root context), "key"
+and "override". Returns base64 - the callers write it straight into a Secret's data.
+*/}}
+{{- define "pmm.secret.key" -}}
+{{- $ctx := .ctx -}}
+{{- $existing := (lookup "v1" "Secret" $ctx.Release.Namespace $ctx.Values.secret.name) -}}
+{{- $current := "" -}}
+{{/* An empty secret.name makes lookup return a SecretList, which has no .data. */}}
+{{- if and $existing $existing.data -}}
+{{- $current = get $existing.data .key -}}
+{{- end -}}
+{{- if $current -}}
+{{- $current -}}
+{{- else if .override -}}
+{{- .override | b64enc -}}
+{{- else -}}
+{{- $cache := printf "generated_%s" .key -}}
+{{- if not (hasKey $ctx.Values $cache) -}}
+{{- $_ := set $ctx.Values $cache (randAlphaNum 32 | b64enc) -}}
+{{- end -}}
+{{- get $ctx.Values $cache -}}
+{{- end -}}
+{{- end -}}

--- a/charts/pmm-ha/templates/pg-user-credentials-secrets.yaml
+++ b/charts/pmm-ha/templates/pg-user-credentials-secrets.yaml
@@ -1,15 +1,28 @@
+{{- $gfPassword := "" }}
+{{- $pgPassword := "" }}
+{{- if .Values.secret.create }}
+{{/*
+Under secret.create the PMM secret is created by secret.yaml's pre-install hook, which has not run
+yet: Helm renders every template before it applies any hook. Looking the secret up here and failing
+when it is absent is what made secret.create unusable for a fresh install. Derive the two passwords
+through the same helper secret.yaml uses instead, so both templates write the same value.
+*/}}
+{{- $gfPassword = include "pmm.secret.key" (dict "ctx" $ "key" "GF_PASSWORD" "override" .Values.secret.gf_password) }}
+{{- $pgPassword = include "pmm.secret.key" (dict "ctx" $ "key" "PG_PASSWORD" "override" .Values.secret.pg_password) }}
+{{- else }}
 {{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace .Values.secret.name) }}
 {{- if not $existingSecret }}
 {{- fail (printf "Secret '%s' not found in namespace '%s'. Please ensure the secret exists before installing this chart." .Values.secret.name .Release.Namespace) }}
 {{- end }}
 {{- $existingData := $existingSecret.data }}
-{{- $gfPassword := get $existingData "GF_PASSWORD" }}
-{{- $pgPassword := get $existingData "PG_PASSWORD" }}
+{{- $gfPassword = get $existingData "GF_PASSWORD" }}
+{{- $pgPassword = get $existingData "PG_PASSWORD" }}
 {{- if not $gfPassword }}
 {{- fail (printf "Secret '%s' is missing required key 'GF_PASSWORD'. Please add this key to the secret." .Values.secret.name) }}
 {{- end }}
 {{- if not $pgPassword }}
 {{- fail (printf "Secret '%s' is missing required key 'PG_PASSWORD'. Please add this key to the secret." .Values.secret.name) }}
+{{- end }}
 {{- end }}
 ---
 # Grafana PostgreSQL user credentials

--- a/charts/pmm-ha/templates/secret.yaml
+++ b/charts/pmm-ha/templates/secret.yaml
@@ -30,8 +30,14 @@ data:
   PMM_CLICKHOUSE_PASSWORD: {{ get $existingData "PMM_CLICKHOUSE_PASSWORD" | default (.Values.secret.clickhouse_password | default (randAlphaNum 32) | b64enc) | quote }}
   VMAGENT_remoteWrite_basicAuth_username: {{ get $existingData "VMAGENT_remoteWrite_basicAuth_username" | default (.Values.secret.victoriametrics_user | default "victoriametrics_pmm" | b64enc) | quote }}
   VMAGENT_remoteWrite_basicAuth_password: {{ get $existingData "VMAGENT_remoteWrite_basicAuth_password" | default (.Values.secret.victoriametrics_password | default (randAlphaNum 32) | b64enc) | quote }}
-  PG_PASSWORD: {{ get $existingData "PG_PASSWORD" | default (.Values.secret.pg_password | default (randAlphaNum 32) | b64enc) | quote }}
-  GF_PASSWORD: {{ get $existingData "GF_PASSWORD" | default (.Values.secret.gf_password | default (randAlphaNum 32) | b64enc) | quote }}
+{{/*
+  These two go through pmm.secret.key because pg-user-credentials-secrets.yaml has to write the
+  same two passwords into the PostgreSQL operator's per-user credentials secrets, and on a fresh
+  install it cannot read them back from a secret this hook has not created yet. Generating them
+  inline here would leave the two templates with different passwords.
+*/}}
+  PG_PASSWORD: {{ include "pmm.secret.key" (dict "ctx" $ "key" "PG_PASSWORD" "override" .Values.secret.pg_password) | quote }}
+  GF_PASSWORD: {{ include "pmm.secret.key" (dict "ctx" $ "key" "GF_PASSWORD" "override" .Values.secret.gf_password) | quote }}
   {{- if or (get $existingData "GF_AUTH_GENERIC_OAUTH_CLIENT_ID") (.Values.secret.GF_AUTH_GENERIC_OAUTH_CLIENT_ID) }}
   GF_AUTH_GENERIC_OAUTH_CLIENT_ID: {{ get $existingData "GF_AUTH_GENERIC_OAUTH_CLIENT_ID" | default .Values.secret.GF_AUTH_GENERIC_OAUTH_CLIENT_ID | quote }}
   {{- end }}


### PR DESCRIPTION
## Problem

`charts/pmm-ha/templates/pg-user-credentials-secrets.yaml` looked up `pmm-secret` at render
time and failed when it was absent. Under `secret.create: true` that secret is created by
`secret.yaml`'s own `pre-install` hook, and Helm renders every template before it applies any
hook, so a fresh install always aborted:

```
$ helm template pmm-ha charts/pmm-ha -n fresh --dry-run=server --set secret.create=true
Error: execution error at (pmm-ha/templates/pg-user-credentials-secrets.yaml:3:4):
Secret 'pmm-secret' not found in namespace 'fresh'.
```

`secret.create` only ever worked on an upgrade, where the secret already existed. Nothing
caught it: `.github/workflows/pmm-ha-pr-checks.yaml` pre-creates the secret and never sets
`secret.create=true`, and the default is `false`.

## Fix

Guarding the lookup on `secret.create` is not enough — the template also needs the
`GF_PASSWORD` and `PG_PASSWORD` values to write the PostgreSQL operator's `gfuser-credentials`
and `pmmuser-credentials` secrets, and a second `randAlphaNum 32` here would hand Grafana a
password PostgreSQL never received.

Both templates now resolve those keys through one `pmm.secret.key` helper: the key already
in the secret, then the `values.yaml` override, then a generated value cached on `.Values` so
every caller gets the same one. That is the approach `pmm.clickhouse.datasourcePassword`
already uses.

`secret.create: false` is untouched: it still reads the pre-created secret and still fails with
the same messages when the secret or a key is missing.

## The same split also broke remote write

`GF_PASSWORD` and `PG_PASSWORD` are not the only keys a second template has to agree on.
`vmauth.yaml` looked `pmm-secret` up the same way and fell back to its own `randAlphaNum 32`,
while `secret.yaml` generated `VMAGENT_remoteWrite_basicAuth_password` independently — so on a
fresh `secret.create` install the two drew different passwords. `vmagent.yaml` and
`statefulset.yaml` read the pair out of `pmm-secret` with a `secretKeyRef`; vmauth validated
incoming requests against its own copy.

Until this PR `secret.create` aborted the render outright, so the mismatch was unreachable.
Making that path installable is what exposes it, and the result is not a render failure — the
release reports `deployed` and then drops every metric:

```
vmagent_remotewrite_requests_total{status_code="2XX"} 0
vmagent_remotewrite_requests_total{status_code="401"} 10

error  remotewrite/client.go:511  unexpected status code received after sending a block
       with size 11745 bytes to "1:secret-url" during retry #6: 401;
       response body="Unauthorized\n"; re-sending the block in 32s
```

Both VM keys now go through `pmm.secret.key` as well. `pmm.validateSecret` stays ahead of the
call: with a pre-created secret missing one of these keys the helper falls back to a generated
value rather than failing, so that include is what keeps reporting the missing key.

## Verified

On EKS, `--dry-run=server` against a live API plus real installs and upgrades in scratch
namespaces:

| Check | Result |
|---|---|
| Fresh namespace, no secret, `secret.create=true` | renders (fails on `PMM-HA-GA`) |
| `helm install --set secret.create=true` | **succeeds**, release `deployed` |
| `pmm-secret.GF_PASSWORD` vs `gfuser-credentials.password` | identical |
| `pmm-secret.PG_PASSWORD` vs `pmmuser-credentials.password` | identical |
| `pmm-secret.VMAGENT_remoteWrite_basicAuth_*` vs the vmauth config | identical |
| vmagent remote write, before this PR's VM commit | 0 x 2XX, **10 x 401** |
| vmagent remote write, after | **91 x 2XX, 0 x 401**, 0 packets dropped |
| vmauth log, authentication failures | none |
| `helm upgrade` on that release | passwords preserved, still matching |
| `--set secret.gf_password=...` / `secret.victoriametrics_password=...` | honoured everywhere |
| Pre-existing secret + `secret.create=true` | existing values reused, not regenerated |
| `secret.create=false`, complete secret | values read verbatim, `pmm-secret` untouched |
| `secret.create=false`, secret absent | unchanged "Secret not found" message |
| `secret.create=false`, secret missing a key | unchanged `pmm.validateSecret` message |
| Every credential pinned, before vs after | renders byte-identical |
| `helm lint` | passes |

No `Chart.yaml` bump, matching the release-time bump convention on this branch.

## Note on the per-key checks

This PR also drops the per-key `GF_PASSWORD` / `PG_PASSWORD` checks in
`pg-user-credentials-secrets.yaml`. They are unreachable now that `pmm.validateSecret` from
#944 has landed: the `secret.create` path no longer reaches them, and on the pre-created-secret
path `statefulset.yaml` and `vmauth.yaml` render first and report every missing key in one
message. The branch is merged with the current `PMM-HA-GA`, which includes #944 and #941.
